### PR TITLE
feat: v2.0 quick wins — sitemap, robots, site-wide OG image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.env.local

--- a/jamesduxbury/src/app/layout.tsx
+++ b/jamesduxbury/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { GeistSans } from 'geist/font/sans';
 import { JetBrains_Mono } from 'next/font/google';
 import { StatusBar } from '@/components/console/StatusBar';
+import { SITE_URL } from '@/lib/site';
 import './globals.css';
 
 const jetbrainsMono = JetBrains_Mono({
@@ -11,6 +12,7 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: 'James Duxbury — Software Engineer in AI and Cybersecurity',
   description:
     'Final-year MEng Computer Science student at Durham. AI / NLP research, application security, full-stack engineering. Accredited Affiliate Member of the Chartered Institute of Information Security (AfCIIS).',
@@ -19,7 +21,15 @@ export const metadata: Metadata = {
     title: 'James Duxbury — Software Engineer in AI and Cybersecurity',
     description:
       'Portfolio of James Duxbury — MEng Computer Science, Durham. AI, NLP, application security, full-stack engineering.',
+    url: SITE_URL,
+    siteName: 'James Duxbury',
     type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'James Duxbury — Software Engineer in AI and Cybersecurity',
+    description:
+      'Portfolio of James Duxbury — MEng Computer Science, Durham. AI, NLP, application security, full-stack engineering.',
   },
 };
 

--- a/jamesduxbury/src/app/opengraph-image.tsx
+++ b/jamesduxbury/src/app/opengraph-image.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from 'next/og';
+import { SITE_HOST } from '@/lib/site';
 
 export const alt = 'James Duxbury — Software Engineer in AI and Cybersecurity';
 export const size = { width: 1200, height: 630 };
@@ -73,7 +74,7 @@ export default function OpenGraphImage() {
         }}
       >
         <span>MEng Computer Science · Durham</span>
-        <span>jamesduxbury-dot-com.vercel.app</span>
+        <span>{SITE_HOST}</span>
       </div>
     </div>,
     size,

--- a/jamesduxbury/src/app/opengraph-image.tsx
+++ b/jamesduxbury/src/app/opengraph-image.tsx
@@ -1,0 +1,81 @@
+import { ImageResponse } from 'next/og';
+
+export const alt = 'James Duxbury — Software Engineer in AI and Cybersecurity';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+// Mirrors the console theme in tailwind.config.ts (satori can't read Tailwind).
+const colours = {
+  bg: '#0A0A14',
+  border: '#2A2A35',
+  text: '#F5F5F0',
+  muted: '#8B8B95',
+  accent: '#3B82F6',
+  live: '#22C55E',
+};
+
+export default function OpenGraphImage() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        padding: '56px 72px',
+        backgroundColor: colours.bg,
+        backgroundImage: `radial-gradient(circle at 1px 1px, rgba(245, 245, 240, 0.08) 1px, transparent 0)`,
+        backgroundSize: '24px 24px',
+        color: colours.text,
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '14px',
+          fontSize: 26,
+          letterSpacing: '0.2em',
+          color: colours.muted,
+        }}
+      >
+        <div
+          style={{
+            width: 14,
+            height: 14,
+            borderRadius: '50%',
+            backgroundColor: colours.live,
+          }}
+        />
+        <span style={{ color: colours.live }}>LIVE</span>
+        <span style={{ color: colours.border }}>·</span>
+        <span style={{ color: colours.text }}>ENG-CONSOLE</span>
+        <span>v2.0</span>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '18px' }}>
+        <div style={{ fontSize: 86, fontWeight: 700, letterSpacing: '0.04em' }}>James Duxbury</div>
+        <div style={{ fontSize: 36, color: colours.accent, letterSpacing: '0.08em' }}>
+          Software Engineer — AI &amp; Cybersecurity
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          borderTop: `2px solid ${colours.border}`,
+          paddingTop: '28px',
+          fontSize: 24,
+          letterSpacing: '0.15em',
+          color: colours.muted,
+        }}
+      >
+        <span>MEng Computer Science · Durham</span>
+        <span>jamesduxbury-dot-com.vercel.app</span>
+      </div>
+    </div>,
+    size,
+  );
+}

--- a/jamesduxbury/src/app/robots.ts
+++ b/jamesduxbury/src/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next';
+import { SITE_URL } from '@/lib/site';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      // /api is server-only; /admin arrives with the v2.0 admin console.
+      disallow: ['/api/', '/admin/'],
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  };
+}

--- a/jamesduxbury/src/app/sitemap.ts
+++ b/jamesduxbury/src/app/sitemap.ts
@@ -1,0 +1,10 @@
+import type { MetadataRoute } from 'next';
+import { SITE_ROUTES, SITE_URL } from '@/lib/site';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return SITE_ROUTES.map((route) => ({
+    url: `${SITE_URL}${route === '/' ? '' : route}`,
+    changeFrequency: 'monthly',
+    priority: route === '/' ? 1 : 0.7,
+  }));
+}

--- a/jamesduxbury/src/lib/site.ts
+++ b/jamesduxbury/src/lib/site.ts
@@ -1,6 +1,10 @@
-/** Canonical site origin, overridable per environment. */
-export const SITE_URL =
-  process.env.NEXT_PUBLIC_SITE_URL ?? 'https://jamesduxbury-dot-com.vercel.app';
+/** Canonical site origin, overridable per environment. Trailing slashes are stripped. */
+export const SITE_URL = (
+  process.env.NEXT_PUBLIC_SITE_URL ?? 'https://jamesduxbury-dot-com.vercel.app'
+).replace(/\/+$/, '');
+
+/** Bare hostname of the canonical origin, for display (e.g. the OG card footer). */
+export const SITE_HOST = new URL(SITE_URL).hostname;
 
 /** Public routes, used by the sitemap. */
 export const SITE_ROUTES = [

--- a/jamesduxbury/src/lib/site.ts
+++ b/jamesduxbury/src/lib/site.ts
@@ -1,0 +1,14 @@
+/** Canonical site origin, overridable per environment. */
+export const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? 'https://jamesduxbury-dot-com.vercel.app';
+
+/** Public routes, used by the sitemap. */
+export const SITE_ROUTES = [
+  '/',
+  '/about',
+  '/work',
+  '/skills',
+  '/experience',
+  '/education',
+  '/contact',
+] as const;


### PR DESCRIPTION
## Summary

First PR of the v2.0 milestone, bundling the small standalone issues so the DB and admin PRs can follow cleanly.

### #9 — SEO and social metadata
- `src/lib/site.ts`: canonical `SITE_URL` (overridable via `NEXT_PUBLIC_SITE_URL`) and the public route list.
- `src/app/sitemap.ts`: sitemap covering all 7 public routes.
- `src/app/robots.ts`: allow all, disallow `/api/` and `/admin/` (the latter ahead of the v2.0 admin console), sitemap reference.
- `src/app/opengraph-image.tsx`: social-share card generated at build time via `next/og`, matching the console theme.
- Root layout: `metadataBase`, `og:url`/`siteName`, Twitter card.

### #7 — /work key warnings
No code change required. The warnings no longer reproduce on a clean `npm run dev` + `/work` render (zero key warnings in the dev log across `/` and `/work`); they appear to have been resolved by the earlier dead-UI-primitive cleanup (5196c5c). All `.map()` calls in the work components use stable content-derived keys.

### #12 (CI slice)
No change needed — the existing workflow (format/lint/typecheck/build) passes as-is. The remaining CI work stays in #12 (v3.0).

## Verification
- `/sitemap.xml`, `/robots.txt`, `/opengraph-image` verified against the dev server.
- Prettier, ESLint, typecheck, and production build all pass.

Closes #7
Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)