### PR TITLE
feat(db): Neon Postgres content, seed pipeline, visit analytics collection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,9 +44,10 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL_DEV }}
 
-  # Insert-if-missing seed: safe to repeat, never overwrites admin edits
+  # One-off prod population, run manually via the Actions tab after merging this PR.
+  # Never triggered by pushes or PRs; the seed is also insert-if-missing as a second guard.
   populate-production:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch'
     needs: check
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,5 +34,34 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: Test
+        run: npm test
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_DEV }}
+
       - name: Build
         run: npm run build
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_DEV }}
+
+  # Insert-if-missing seed: safe to repeat, never overwrites admin edits
+  populate-production:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: jamesduxbury/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Migrate and seed production
+        run: npm run db:migrate && npm run db:seed
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_MAIN }}

--- a/jamesduxbury/.env.example
+++ b/jamesduxbury/.env.example
@@ -1,0 +1,3 @@
+# Neon Postgres connection string.
+# Local dev + CI use the dev branch; Vercel production uses the main branch.
+DATABASE_URL=postgresql://user:password@host/dbname?sslmode=require

--- a/jamesduxbury/.gitignore
+++ b/jamesduxbury/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/jamesduxbury/package-lock.json
+++ b/jamesduxbury/package-lock.json
@@ -19,21 +19,34 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^20",
         "@types/nodemailer": "^8.0.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/tailwindcss": "^3.1.0",
+        "@vitejs/plugin-react": "^6.0.2",
+        "@vitest/coverage-v8": "^4.1.8",
         "eslint": "^9",
         "eslint-config-next": "^15.5.18",
+        "jsdom": "^29.1.1",
         "postcss": "^8.4.31",
         "postcss-import": "^16.1.0",
         "prettier": "^3.8.3",
         "prettier-plugin-tailwindcss": "^0.6.14",
         "tailwindcss": "^3.4.17",
         "tsx": "^4.22.4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.8"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -47,10 +60,323 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -641,6 +967,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1219,19 +1563,40 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@neondatabase/serverless": {
@@ -1431,6 +1796,16 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1440,6 +1815,270 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -1453,6 +2092,13 @@
       "integrity": "sha512-kkKUDVlII2DQiKy7UstOR1ErJP8kUKAQ4oa+SQtM0K+lPdmmjj0YnnxBgtTVYH7mUKtbsxeFC9y0AmK7Yb78/A==",
       "dev": true
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1460,6 +2106,130 @@
       "dependencies": {
         "tslib": "^2.8.0"
       }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",
@@ -1481,12 +2251,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.17.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.17.tgz",
-      "integrity": "sha512-/WndGO4kIfMicEQLTi/mDANUu/iVUhT7KboZPdEqqHQ4aTS+3qT3U5gIqWDFV+XouorjfgGqvKILJeHhuQgFYg==",
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/nodemailer": {
@@ -1753,6 +2524,149 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
+      "integrity": "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.8",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2008,11 +2922,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
+      "integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -2097,6 +3040,16 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -2248,6 +3201,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2338,6 +3301,13 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2351,6 +3321,27 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -2375,6 +3366,20 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -2444,6 +3449,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2484,12 +3496,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2517,6 +3540,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2560,6 +3591,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -2671,6 +3715,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -3216,6 +4267,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3223,6 +4284,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3738,6 +4809,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3770,6 +4861,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/internal-slot": {
@@ -4034,6 +5135,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -4182,6 +5290,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -4240,6 +5387,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/json-buffer": {
@@ -4327,6 +5525,267 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -4384,6 +5843,55 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4392,6 +5900,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4413,6 +5928,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -4735,6 +6260,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
+      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4817,6 +6356,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4856,6 +6408,13 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4903,9 +6462,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -4922,7 +6481,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5156,6 +6715,55 @@
         }
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -5242,6 +6850,20 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -5282,6 +6904,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -5330,6 +6962,40 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/run-parallel": {
@@ -5405,6 +7071,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -5609,6 +7288,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -5634,6 +7320,20 @@
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.4.tgz",
       "integrity": "sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==",
       "dev": true
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -5847,6 +7547,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -5926,6 +7639,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.17",
@@ -6039,6 +7759,101 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.2"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6049,6 +7864,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -6222,11 +8063,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.1.tgz",
+      "integrity": "sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.2",
@@ -6271,6 +8123,275 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -6371,6 +8492,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -6467,6 +8605,23 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yaml": {
       "version": "2.8.4",

--- a/jamesduxbury/package-lock.json
+++ b/jamesduxbury/package-lock.json
@@ -8,6 +8,7 @@
       "name": "jamesduxbury",
       "version": "0.1.0",
       "dependencies": {
+        "@neondatabase/serverless": "^1.1.0",
         "autoprefixer": "^10.4.20",
         "framer-motion": "^12.38.0",
         "geist": "^1.7.0",
@@ -30,6 +31,7 @@
         "prettier": "^3.8.3",
         "prettier-plugin-tailwindcss": "^0.6.14",
         "tailwindcss": "^3.4.17",
+        "tsx": "^4.22.4",
         "typescript": "^5"
       }
     },
@@ -53,6 +55,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -788,6 +1232,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@neondatabase/serverless": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.1.0.tgz",
+      "integrity": "sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=19.0.0"
       }
     },
     "node_modules/@next/env": {
@@ -2270,6 +2723,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/escalade": {
@@ -5590,6 +6085,25 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/jamesduxbury/package.json
+++ b/jamesduxbury/package.json
@@ -10,9 +10,12 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,css,json,md}\"",
-    "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,css,json,md}\""
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,css,json,md}\"",
+    "db:migrate": "tsx src/db/migrate.ts",
+    "db:push": "tsx src/db/migrate.ts --push"
   },
   "dependencies": {
+    "@neondatabase/serverless": "^1.1.0",
     "autoprefixer": "^10.4.20",
     "framer-motion": "^12.38.0",
     "geist": "^1.7.0",
@@ -35,6 +38,7 @@
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.6.14",
     "tailwindcss": "^3.4.17",
+    "tsx": "^4.22.4",
     "typescript": "^5"
   }
 }

--- a/jamesduxbury/package.json
+++ b/jamesduxbury/package.json
@@ -12,7 +12,8 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,css,json,md}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,css,json,md}\"",
     "db:migrate": "tsx src/db/migrate.ts",
-    "db:push": "tsx src/db/migrate.ts --push"
+    "db:push": "tsx src/db/migrate.ts --push",
+    "db:seed": "tsx scripts/seed.ts"
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.1.0",

--- a/jamesduxbury/package.json
+++ b/jamesduxbury/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://jamesduxbury-dot-com.vercel.app/",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "tsx src/db/migrate.ts && next build",
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
@@ -13,7 +13,9 @@
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,css,json,md}\"",
     "db:migrate": "tsx src/db/migrate.ts",
     "db:push": "tsx src/db/migrate.ts --push",
-    "db:seed": "tsx scripts/seed.ts"
+    "db:seed": "tsx scripts/seed.ts",
+    "test": "vitest run --coverage",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.1.0",
@@ -27,19 +29,25 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^20",
     "@types/nodemailer": "^8.0.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/tailwindcss": "^3.1.0",
+    "@vitejs/plugin-react": "^6.0.2",
+    "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^9",
     "eslint-config-next": "^15.5.18",
+    "jsdom": "^29.1.1",
     "postcss": "^8.4.31",
     "postcss-import": "^16.1.0",
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.6.14",
     "tailwindcss": "^3.4.17",
     "tsx": "^4.22.4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.8"
   }
 }

--- a/jamesduxbury/scripts/seed.ts
+++ b/jamesduxbury/scripts/seed.ts
@@ -24,13 +24,7 @@ async function main(): Promise<void> {
         ${p.yearStart}, ${p.yearEnd}, ${p.techStack}, ${p.highlights},
         ${p.metrics ? JSON.stringify(p.metrics) : null}, ${p.imagePath ?? null},
         ${p.githubLink ?? null}, ${p.liveLink ?? null}, ${i})
-      ON CONFLICT (slug) DO UPDATE SET
-        title = EXCLUDED.title, subtitle = EXCLUDED.subtitle, status = EXCLUDED.status,
-        under_exam = EXCLUDED.under_exam, year_start = EXCLUDED.year_start,
-        year_end = EXCLUDED.year_end, tech_stack = EXCLUDED.tech_stack,
-        highlights = EXCLUDED.highlights, metrics = EXCLUDED.metrics,
-        image_path = EXCLUDED.image_path, github_link = EXCLUDED.github_link,
-        live_link = EXCLUDED.live_link, sort_order = EXCLUDED.sort_order, updated_at = now()
+      ON CONFLICT (slug) DO NOTHING
     `;
   }
 
@@ -39,10 +33,7 @@ async function main(): Promise<void> {
       INSERT INTO experience (title, organisation, meta, period, year_start, year_end, bullets, sort_order)
       VALUES (${r.title}, ${r.organisation}, ${r.meta ?? null}, ${r.period}, ${r.yearStart},
         ${r.yearEnd === 'present' ? null : r.yearEnd}, ${r.bullets ?? null}, ${i})
-      ON CONFLICT (title, organisation) DO UPDATE SET
-        meta = EXCLUDED.meta, period = EXCLUDED.period, year_start = EXCLUDED.year_start,
-        year_end = EXCLUDED.year_end, bullets = EXCLUDED.bullets,
-        sort_order = EXCLUDED.sort_order, updated_at = now()
+      ON CONFLICT (title, organisation) DO NOTHING
     `;
   }
 
@@ -50,9 +41,7 @@ async function main(): Promise<void> {
     await sql`
       INSERT INTO education (qualification, institution, period, year_end, bullets, sort_order)
       VALUES (${d.qualification}, ${d.institution}, ${d.period}, ${d.yearEnd}, ${d.bullets ?? null}, ${i})
-      ON CONFLICT (qualification, institution) DO UPDATE SET
-        period = EXCLUDED.period, year_end = EXCLUDED.year_end, bullets = EXCLUDED.bullets,
-        sort_order = EXCLUDED.sort_order, updated_at = now()
+      ON CONFLICT (qualification, institution) DO NOTHING
     `;
   }
 
@@ -60,10 +49,7 @@ async function main(): Promise<void> {
     await sql`
       INSERT INTO certifications (name, year, img_path, certification_link, sort_order)
       VALUES (${c.name}, ${c.year}, ${c.imgPath ?? null}, ${c.certificationLink ?? null}, ${i})
-      ON CONFLICT (name) DO UPDATE SET
-        year = EXCLUDED.year, img_path = EXCLUDED.img_path,
-        certification_link = EXCLUDED.certification_link,
-        sort_order = EXCLUDED.sort_order, updated_at = now()
+      ON CONFLICT (name) DO NOTHING
     `;
   }
 
@@ -71,8 +57,7 @@ async function main(): Promise<void> {
     await sql`
       INSERT INTO skill_groups (heading, skills, sort_order)
       VALUES (${g.heading}, ${g.skills}, ${i})
-      ON CONFLICT (heading) DO UPDATE SET
-        skills = EXCLUDED.skills, sort_order = EXCLUDED.sort_order, updated_at = now()
+      ON CONFLICT (heading) DO NOTHING
     `;
   }
 
@@ -80,7 +65,7 @@ async function main(): Promise<void> {
     await sql`
       INSERT INTO about_paragraphs (runs, sort_order)
       VALUES (${JSON.stringify(runs)}, ${i})
-      ON CONFLICT (sort_order) DO UPDATE SET runs = EXCLUDED.runs, updated_at = now()
+      ON CONFLICT (sort_order) DO NOTHING
     `;
   }
 

--- a/jamesduxbury/scripts/seed.ts
+++ b/jamesduxbury/scripts/seed.ts
@@ -1,0 +1,102 @@
+import { neon } from '@neondatabase/serverless';
+import { loadEnvLocal } from '../src/db/env';
+import { projects } from '../src/data/projects';
+import { roles } from '../src/data/experience';
+import { degrees } from '../src/data/education';
+import { certifications } from '../src/data/certifications';
+import { skillGroups } from '../src/data/skills';
+import { aboutParagraphs } from '../src/data/about';
+
+async function main(): Promise<void> {
+  loadEnvLocal();
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    console.error('DATABASE_URL is not set (env or .env.local).');
+    process.exit(1);
+  }
+  const sql = neon(url);
+
+  for (const [i, p] of projects.entries()) {
+    await sql`
+      INSERT INTO projects (slug, title, subtitle, status, under_exam, year_start, year_end,
+        tech_stack, highlights, metrics, image_path, github_link, live_link, sort_order)
+      VALUES (${p.slug}, ${p.title}, ${p.subtitle}, ${p.status}, ${p.underExam ?? false},
+        ${p.yearStart}, ${p.yearEnd}, ${p.techStack}, ${p.highlights},
+        ${p.metrics ? JSON.stringify(p.metrics) : null}, ${p.imagePath ?? null},
+        ${p.githubLink ?? null}, ${p.liveLink ?? null}, ${i})
+      ON CONFLICT (slug) DO UPDATE SET
+        title = EXCLUDED.title, subtitle = EXCLUDED.subtitle, status = EXCLUDED.status,
+        under_exam = EXCLUDED.under_exam, year_start = EXCLUDED.year_start,
+        year_end = EXCLUDED.year_end, tech_stack = EXCLUDED.tech_stack,
+        highlights = EXCLUDED.highlights, metrics = EXCLUDED.metrics,
+        image_path = EXCLUDED.image_path, github_link = EXCLUDED.github_link,
+        live_link = EXCLUDED.live_link, sort_order = EXCLUDED.sort_order, updated_at = now()
+    `;
+  }
+
+  for (const [i, r] of roles.entries()) {
+    await sql`
+      INSERT INTO experience (title, organisation, meta, period, year_start, year_end, bullets, sort_order)
+      VALUES (${r.title}, ${r.organisation}, ${r.meta ?? null}, ${r.period}, ${r.yearStart},
+        ${r.yearEnd === 'present' ? null : r.yearEnd}, ${r.bullets ?? null}, ${i})
+      ON CONFLICT (title, organisation) DO UPDATE SET
+        meta = EXCLUDED.meta, period = EXCLUDED.period, year_start = EXCLUDED.year_start,
+        year_end = EXCLUDED.year_end, bullets = EXCLUDED.bullets,
+        sort_order = EXCLUDED.sort_order, updated_at = now()
+    `;
+  }
+
+  for (const [i, d] of degrees.entries()) {
+    await sql`
+      INSERT INTO education (qualification, institution, period, year_end, bullets, sort_order)
+      VALUES (${d.qualification}, ${d.institution}, ${d.period}, ${d.yearEnd}, ${d.bullets ?? null}, ${i})
+      ON CONFLICT (qualification, institution) DO UPDATE SET
+        period = EXCLUDED.period, year_end = EXCLUDED.year_end, bullets = EXCLUDED.bullets,
+        sort_order = EXCLUDED.sort_order, updated_at = now()
+    `;
+  }
+
+  for (const [i, c] of certifications.entries()) {
+    await sql`
+      INSERT INTO certifications (name, year, img_path, certification_link, sort_order)
+      VALUES (${c.name}, ${c.year}, ${c.imgPath ?? null}, ${c.certificationLink ?? null}, ${i})
+      ON CONFLICT (name) DO UPDATE SET
+        year = EXCLUDED.year, img_path = EXCLUDED.img_path,
+        certification_link = EXCLUDED.certification_link,
+        sort_order = EXCLUDED.sort_order, updated_at = now()
+    `;
+  }
+
+  for (const [i, g] of skillGroups.entries()) {
+    await sql`
+      INSERT INTO skill_groups (heading, skills, sort_order)
+      VALUES (${g.heading}, ${g.skills}, ${i})
+      ON CONFLICT (heading) DO UPDATE SET
+        skills = EXCLUDED.skills, sort_order = EXCLUDED.sort_order, updated_at = now()
+    `;
+  }
+
+  for (const [i, runs] of aboutParagraphs.entries()) {
+    await sql`
+      INSERT INTO about_paragraphs (runs, sort_order)
+      VALUES (${JSON.stringify(runs)}, ${i})
+      ON CONFLICT (sort_order) DO UPDATE SET runs = EXCLUDED.runs, updated_at = now()
+    `;
+  }
+
+  const counts = await sql`
+    SELECT
+      (SELECT count(*) FROM projects) AS projects,
+      (SELECT count(*) FROM experience) AS experience,
+      (SELECT count(*) FROM education) AS education,
+      (SELECT count(*) FROM certifications) AS certifications,
+      (SELECT count(*) FROM skill_groups) AS skill_groups,
+      (SELECT count(*) FROM about_paragraphs) AS about_paragraphs
+  `;
+  console.log('seeded:', counts[0]);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/jamesduxbury/scripts/seed.ts
+++ b/jamesduxbury/scripts/seed.ts
@@ -1,87 +1,16 @@
 import { neon } from '@neondatabase/serverless';
 import { loadEnvLocal } from '../src/db/env';
-import { projects } from '../src/data/projects';
-import { roles } from '../src/data/experience';
-import { degrees } from '../src/data/education';
-import { certifications } from '../src/data/certifications';
-import { skillGroups } from '../src/data/skills';
-import { aboutParagraphs } from '../src/data/about';
+import { seed } from '../src/db/seed';
 
-async function main(): Promise<void> {
-  loadEnvLocal();
-  const url = process.env.DATABASE_URL;
-  if (!url) {
-    console.error('DATABASE_URL is not set (env or .env.local).');
-    process.exit(1);
-  }
-  const sql = neon(url);
-
-  for (const [i, p] of projects.entries()) {
-    await sql`
-      INSERT INTO projects (slug, title, subtitle, status, under_exam, year_start, year_end,
-        tech_stack, highlights, metrics, image_path, github_link, live_link, sort_order)
-      VALUES (${p.slug}, ${p.title}, ${p.subtitle}, ${p.status}, ${p.underExam ?? false},
-        ${p.yearStart}, ${p.yearEnd}, ${p.techStack}, ${p.highlights},
-        ${p.metrics ? JSON.stringify(p.metrics) : null}, ${p.imagePath ?? null},
-        ${p.githubLink ?? null}, ${p.liveLink ?? null}, ${i})
-      ON CONFLICT (slug) DO NOTHING
-    `;
-  }
-
-  for (const [i, r] of roles.entries()) {
-    await sql`
-      INSERT INTO experience (title, organisation, meta, period, year_start, year_end, bullets, sort_order)
-      VALUES (${r.title}, ${r.organisation}, ${r.meta ?? null}, ${r.period}, ${r.yearStart},
-        ${r.yearEnd === 'present' ? null : r.yearEnd}, ${r.bullets ?? null}, ${i})
-      ON CONFLICT (title, organisation) DO NOTHING
-    `;
-  }
-
-  for (const [i, d] of degrees.entries()) {
-    await sql`
-      INSERT INTO education (qualification, institution, period, year_end, bullets, sort_order)
-      VALUES (${d.qualification}, ${d.institution}, ${d.period}, ${d.yearEnd}, ${d.bullets ?? null}, ${i})
-      ON CONFLICT (qualification, institution) DO NOTHING
-    `;
-  }
-
-  for (const [i, c] of certifications.entries()) {
-    await sql`
-      INSERT INTO certifications (name, year, img_path, certification_link, sort_order)
-      VALUES (${c.name}, ${c.year}, ${c.imgPath ?? null}, ${c.certificationLink ?? null}, ${i})
-      ON CONFLICT (name) DO NOTHING
-    `;
-  }
-
-  for (const [i, g] of skillGroups.entries()) {
-    await sql`
-      INSERT INTO skill_groups (heading, skills, sort_order)
-      VALUES (${g.heading}, ${g.skills}, ${i})
-      ON CONFLICT (heading) DO NOTHING
-    `;
-  }
-
-  for (const [i, runs] of aboutParagraphs.entries()) {
-    await sql`
-      INSERT INTO about_paragraphs (runs, sort_order)
-      VALUES (${JSON.stringify(runs)}, ${i})
-      ON CONFLICT (sort_order) DO NOTHING
-    `;
-  }
-
-  const counts = await sql`
-    SELECT
-      (SELECT count(*) FROM projects) AS projects,
-      (SELECT count(*) FROM experience) AS experience,
-      (SELECT count(*) FROM education) AS education,
-      (SELECT count(*) FROM certifications) AS certifications,
-      (SELECT count(*) FROM skill_groups) AS skill_groups,
-      (SELECT count(*) FROM about_paragraphs) AS about_paragraphs
-  `;
-  console.log('seeded:', counts[0]);
-}
-
-main().catch((err) => {
-  console.error(err);
+loadEnvLocal();
+const url = process.env.DATABASE_URL;
+if (!url) {
+  console.error('DATABASE_URL is not set (env or .env.local).');
   process.exit(1);
-});
+}
+seed(neon(url))
+  .then((counts) => console.log('seeded:', counts))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/jamesduxbury/src/app/about/page.tsx
+++ b/jamesduxbury/src/app/about/page.tsx
@@ -9,6 +9,8 @@ export const metadata: Metadata = {
     'About James Duxbury — final-year MEng Computer Science student at Durham, specialising in AI and application security.',
 };
 
+export const revalidate = 60;
+
 export default function AboutPage() {
   return (
     <>

--- a/jamesduxbury/src/app/api/contact/route.ts
+++ b/jamesduxbury/src/app/api/contact/route.ts
@@ -66,9 +66,11 @@ export async function POST(req: Request) {
 
   const correlationId = randomUUID();
 
-  // Stored before the email so a transport failure can't lose the submission
+  // Two delivery channels; the request only fails if both do
+  let stored = false;
   try {
     await getSql()`INSERT INTO messages (name, email, message) VALUES (${name}, ${email}, ${message})`;
+    stored = true;
   } catch (error) {
     console.error(`[contact:${correlationId}] message insert failed`, error);
   }
@@ -97,6 +99,10 @@ export async function POST(req: Request) {
   } catch (error) {
     // Log full error server-side; never return transport / auth / host details to the client.
     console.error(`[contact:${correlationId}]`, error);
+    if (stored) {
+      // Persisted for the admin inbox, so the submission is not lost
+      return Response.json({ success: true });
+    }
     return Response.json(
       {
         success: false,

--- a/jamesduxbury/src/app/api/contact/route.ts
+++ b/jamesduxbury/src/app/api/contact/route.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import nodemailer from 'nodemailer';
+import { getSql } from '@/db';
 
 interface ContactPayload {
   name: string;
@@ -64,6 +65,13 @@ export async function POST(req: Request) {
   const headerSafeEmail = sanitiseHeaderValue(email, 320);
 
   const correlationId = randomUUID();
+
+  // Stored before the email so a transport failure can't lose the submission
+  try {
+    await getSql()`INSERT INTO messages (name, email, message) VALUES (${name}, ${email}, ${message})`;
+  } catch (error) {
+    console.error(`[contact:${correlationId}] message insert failed`, error);
+  }
 
   try {
     const transporter = nodemailer.createTransport({

--- a/jamesduxbury/src/app/api/visit/route.ts
+++ b/jamesduxbury/src/app/api/visit/route.ts
@@ -25,14 +25,16 @@ export async function POST(req: Request) {
   }
 
   // Exit beacon: records how long the view lasted
-  if (typeof body.id === 'number') {
+  if (body.id !== undefined) {
+    // bigserial ids travel as strings to avoid a 32-bit assumption in the contract
+    const id = typeof body.id === 'string' && /^\d{1,18}$/.test(body.id) ? body.id : null;
     const durationMs = typeof body.durationMs === 'number' ? Math.round(body.durationMs) : NaN;
-    if (!Number.isInteger(body.id) || !Number.isFinite(durationMs) || durationMs < 0) {
+    if (id === null || !Number.isFinite(durationMs) || durationMs < 0) {
       return Response.json({ error: 'Invalid payload' }, { status: 400 });
     }
     await getSql()`
       UPDATE page_views SET duration_ms = ${Math.min(durationMs, MAX_DURATION_MS)}
-      WHERE id = ${body.id} AND duration_ms IS NULL
+      WHERE id = ${id}::bigint AND duration_ms IS NULL
     `;
     return new Response(null, { status: 204 });
   }
@@ -45,12 +47,13 @@ export async function POST(req: Request) {
     return Response.json({ error: 'Invalid payload' }, { status: 400 });
   }
 
-  const country = req.headers.get('x-vercel-ip-country');
-  // bigint serialises as a string, so cast for the client round-trip
+  // Public endpoint: the geo header is caller-controlled, so clamp it
+  const countryHeader = req.headers.get('x-vercel-ip-country');
+  const country = countryHeader && /^[A-Z]{2}$/.test(countryHeader) ? countryHeader : null;
   const [row] = await getSql()`
     INSERT INTO page_views (session_id, path, referrer, country)
     VALUES (${sessionId}, ${path}, ${referrer}, ${country})
-    RETURNING id::int
+    RETURNING id
   `;
-  return Response.json({ id: row.id });
+  return Response.json({ id: String(row.id) });
 }

--- a/jamesduxbury/src/app/api/visit/route.ts
+++ b/jamesduxbury/src/app/api/visit/route.ts
@@ -1,0 +1,56 @@
+import { getSql } from '@/db';
+
+const BOT_UA = /bot|crawl|spider|slurp|headless|preview|monitor|lighthouse/i;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_DURATION_MS = 6 * 60 * 60 * 1000;
+
+interface VisitPayload {
+  sessionId?: unknown;
+  path?: unknown;
+  referrer?: unknown;
+  id?: unknown;
+  durationMs?: unknown;
+}
+
+export async function POST(req: Request) {
+  if (BOT_UA.test(req.headers.get('user-agent') ?? '')) {
+    return new Response(null, { status: 204 });
+  }
+
+  let body: VisitPayload;
+  try {
+    body = (await req.json()) as VisitPayload;
+  } catch {
+    return Response.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+
+  // Exit beacon: records how long the view lasted
+  if (typeof body.id === 'number') {
+    const durationMs = typeof body.durationMs === 'number' ? Math.round(body.durationMs) : NaN;
+    if (!Number.isInteger(body.id) || !Number.isFinite(durationMs) || durationMs < 0) {
+      return Response.json({ error: 'Invalid payload' }, { status: 400 });
+    }
+    await getSql()`
+      UPDATE page_views SET duration_ms = ${Math.min(durationMs, MAX_DURATION_MS)}
+      WHERE id = ${body.id} AND duration_ms IS NULL
+    `;
+    return new Response(null, { status: 204 });
+  }
+
+  const sessionId = typeof body.sessionId === 'string' ? body.sessionId : '';
+  const path = typeof body.path === 'string' ? body.path : '';
+  const referrer =
+    typeof body.referrer === 'string' && body.referrer ? body.referrer.slice(0, 500) : null;
+  if (!UUID.test(sessionId) || !path.startsWith('/') || path.length > 200) {
+    return Response.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+
+  const country = req.headers.get('x-vercel-ip-country');
+  // bigint serialises as a string, so cast for the client round-trip
+  const [row] = await getSql()`
+    INSERT INTO page_views (session_id, path, referrer, country)
+    VALUES (${sessionId}, ${path}, ${referrer}, ${country})
+    RETURNING id::int
+  `;
+  return Response.json({ id: row.id });
+}

--- a/jamesduxbury/src/app/education/page.tsx
+++ b/jamesduxbury/src/app/education/page.tsx
@@ -9,6 +9,8 @@ export const metadata: Metadata = {
     'Education and certifications of James Duxbury — MEng Computer Science at Durham, AfCIIS, ITIL 4 Foundation, Azure AI Fundamentals.',
 };
 
+export const revalidate = 60;
+
 export default function EducationPage() {
   return (
     <>

--- a/jamesduxbury/src/app/experience/page.tsx
+++ b/jamesduxbury/src/app/experience/page.tsx
@@ -9,6 +9,8 @@ export const metadata: Metadata = {
     'Professional experience of James Duxbury — Compare the Market, DataAnnotation, Snap-on Tools, Next.',
 };
 
+export const revalidate = 60;
+
 export default function ExperiencePage() {
   return (
     <>

--- a/jamesduxbury/src/app/layout.tsx
+++ b/jamesduxbury/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { GeistSans } from 'geist/font/sans';
 import { JetBrains_Mono } from 'next/font/google';
 import { StatusBar } from '@/components/console/StatusBar';
+import { VisitBeacon } from '@/components/VisitBeacon';
 import { SITE_URL } from '@/lib/site';
 import './globals.css';
 
@@ -42,6 +43,7 @@ export default function RootLayout({
     <html lang="en" className={`${GeistSans.variable} ${jetbrainsMono.variable}`}>
       <body className="bg-bg bg-dot-grid bg-[length:24px_24px] font-sans text-text antialiased">
         <StatusBar />
+        <VisitBeacon />
         {children}
       </body>
     </html>

--- a/jamesduxbury/src/app/page.tsx
+++ b/jamesduxbury/src/app/page.tsx
@@ -6,6 +6,8 @@ import { ExperienceSummary } from '@/components/experience/ExperienceSummary';
 import { EducationSummary } from '@/components/education/EducationSummary';
 import { Footer } from '@/components/Footer';
 
+export const revalidate = 60;
+
 export default function Home() {
   return (
     <>

--- a/jamesduxbury/src/app/skills/page.tsx
+++ b/jamesduxbury/src/app/skills/page.tsx
@@ -9,6 +9,8 @@ export const metadata: Metadata = {
     'Technical skills of James Duxbury — languages, AI/ML, cloud, infrastructure, and development practices.',
 };
 
+export const revalidate = 60;
+
 export default function SkillsPage() {
   return (
     <>

--- a/jamesduxbury/src/app/work/page.tsx
+++ b/jamesduxbury/src/app/work/page.tsx
@@ -9,6 +9,8 @@ export const metadata: Metadata = {
     'Projects by James Duxbury — FG-HAN dissertation, JSGrades, Researcher Agent, X-Ray Image Repair, Artemis III.',
 };
 
+export const revalidate = 60;
+
 export default function WorkPage() {
   return (
     <>

--- a/jamesduxbury/src/components/VisitBeacon.tsx
+++ b/jamesduxbury/src/components/VisitBeacon.tsx
@@ -5,7 +5,8 @@ import { usePathname } from 'next/navigation';
 
 export function VisitBeacon() {
   const pathname = usePathname();
-  const view = useRef<{ id: number | null; start: number }>({ id: null, start: 0 });
+  // ids are bigserial strings end-to-end
+  const view = useRef<{ id: string | null; start: number }>({ id: null, start: 0 });
 
   useEffect(() => {
     if (!pathname || pathname.startsWith('/admin')) return;

--- a/jamesduxbury/src/components/VisitBeacon.tsx
+++ b/jamesduxbury/src/components/VisitBeacon.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { usePathname } from 'next/navigation';
+
+export function VisitBeacon() {
+  const pathname = usePathname();
+  const view = useRef<{ id: number | null; start: number }>({ id: null, start: 0 });
+
+  useEffect(() => {
+    if (!pathname || pathname.startsWith('/admin')) return;
+
+    let sessionId = sessionStorage.getItem('visit-session');
+    // document.referrer goes stale after client-side navigation, so only the first view sends it
+    const referrer = sessionId ? null : document.referrer || null;
+    if (!sessionId) {
+      sessionId = crypto.randomUUID();
+      sessionStorage.setItem('visit-session', sessionId);
+    }
+
+    let cancelled = false;
+    view.current = { id: null, start: Date.now() };
+    fetch('/api/visit', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ sessionId, path: pathname, referrer }),
+      keepalive: true,
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!cancelled && data) view.current.id = data.id;
+      })
+      .catch(() => {});
+
+    const finish = () => {
+      if (view.current.id === null) return;
+      const body = JSON.stringify({
+        id: view.current.id,
+        durationMs: Date.now() - view.current.start,
+      });
+      navigator.sendBeacon('/api/visit', new Blob([body], { type: 'application/json' }));
+      view.current.id = null;
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') finish();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    window.addEventListener('pagehide', finish);
+    return () => {
+      finish();
+      cancelled = true;
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      window.removeEventListener('pagehide', finish);
+    };
+  }, [pathname]);
+
+  return null;
+}

--- a/jamesduxbury/src/components/about/AboutDetail.tsx
+++ b/jamesduxbury/src/components/about/AboutDetail.tsx
@@ -1,13 +1,16 @@
 import { Widget } from '@/components/console/Widget';
-import { aboutParagraphs } from '@/data/about';
+import { getAboutParagraphs } from '@/db/queries';
 import { renderRun } from './renderRun';
 
-export const AboutDetail: React.FC = () => (
-  <Widget channel="01" label="TRANSMISSION" id="about">
-    <div className="space-y-4 px-4 py-6 text-base leading-relaxed text-text/85 sm:px-6 sm:text-lg">
-      {aboutParagraphs.map((paragraph, i) => (
-        <p key={i}>{paragraph.map(renderRun)}</p>
-      ))}
-    </div>
-  </Widget>
-);
+export async function AboutDetail() {
+  const aboutParagraphs = await getAboutParagraphs();
+  return (
+    <Widget channel="01" label="TRANSMISSION" id="about">
+      <div className="space-y-4 px-4 py-6 text-base leading-relaxed text-text/85 sm:px-6 sm:text-lg">
+        {aboutParagraphs.map((paragraph, i) => (
+          <p key={i}>{paragraph.map(renderRun)}</p>
+        ))}
+      </div>
+    </Widget>
+  );
+}

--- a/jamesduxbury/src/components/about/AboutSummary.tsx
+++ b/jamesduxbury/src/components/about/AboutSummary.tsx
@@ -1,23 +1,26 @@
 import Link from 'next/link';
 import { Widget } from '@/components/console/Widget';
-import { aboutParagraphs } from '@/data/about';
+import { getAboutParagraphs } from '@/db/queries';
 import { renderRun } from './renderRun';
 
 const SUMMARY_COUNT = 2;
 
-export const AboutSummary: React.FC = () => (
-  <Widget channel="01" label="TRANSMISSION" id="about">
-    <div className="space-y-4 px-4 py-5 text-sm leading-relaxed text-text/85 sm:px-6 sm:text-base">
-      {aboutParagraphs.slice(0, SUMMARY_COUNT).map((paragraph, i) => (
-        <p key={i}>{paragraph.map(renderRun)}</p>
-      ))}
-    </div>
-    <Link
-      href="/about"
-      className="group flex items-center justify-between border-t border-border bg-bg/40 px-4 py-3 font-mono text-sm uppercase tracking-[0.18em] text-accent transition-colors hover:bg-accent/10 sm:px-6"
-    >
-      <span>+ {aboutParagraphs.length - SUMMARY_COUNT} more paragraphs</span>
-      <span className="transition-transform group-hover:translate-x-1">open /about →</span>
-    </Link>
-  </Widget>
-);
+export async function AboutSummary() {
+  const aboutParagraphs = await getAboutParagraphs();
+  return (
+    <Widget channel="01" label="TRANSMISSION" id="about">
+      <div className="space-y-4 px-4 py-5 text-sm leading-relaxed text-text/85 sm:px-6 sm:text-base">
+        {aboutParagraphs.slice(0, SUMMARY_COUNT).map((paragraph, i) => (
+          <p key={i}>{paragraph.map(renderRun)}</p>
+        ))}
+      </div>
+      <Link
+        href="/about"
+        className="group flex items-center justify-between border-t border-border bg-bg/40 px-4 py-3 font-mono text-sm uppercase tracking-[0.18em] text-accent transition-colors hover:bg-accent/10 sm:px-6"
+      >
+        <span>+ {aboutParagraphs.length - SUMMARY_COUNT} more paragraphs</span>
+        <span className="transition-transform group-hover:translate-x-1">open /about →</span>
+      </Link>
+    </Widget>
+  );
+}

--- a/jamesduxbury/src/components/education/CertificationsBlock.tsx
+++ b/jamesduxbury/src/components/education/CertificationsBlock.tsx
@@ -1,13 +1,9 @@
 import Image from 'next/image';
 import Link from 'next/link';
-import { certifications } from '@/data/certifications';
+import type { Certification } from '@/data/certifications';
+import { getCertifications } from '@/db/queries';
 
-const Card: React.FC<(typeof certifications)[number]> = ({
-  name,
-  year,
-  imgPath,
-  certificationLink,
-}) => {
+const Card: React.FC<Certification> = ({ name, year, imgPath, certificationLink }) => {
   const inner = (
     <div className="flex items-center gap-3 border border-border bg-bg/40 p-3 transition-colors hover:border-accent">
       {imgPath ? (
@@ -43,15 +39,18 @@ const Card: React.FC<(typeof certifications)[number]> = ({
   return inner;
 };
 
-export const CertificationsBlock: React.FC = () => (
-  <div className="border-t border-border bg-bg/40 px-4 py-5 sm:px-6">
-    <p className="font-mono text-xs uppercase tracking-[0.18em] text-muted">
-      Certifications & memberships / {certifications.length}
-    </p>
-    <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
-      {certifications.map((cert) => (
-        <Card key={cert.name} {...cert} />
-      ))}
+export async function CertificationsBlock() {
+  const certifications = await getCertifications();
+  return (
+    <div className="border-t border-border bg-bg/40 px-4 py-5 sm:px-6">
+      <p className="font-mono text-xs uppercase tracking-[0.18em] text-muted">
+        Certifications & memberships / {certifications.length}
+      </p>
+      <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {certifications.map((cert) => (
+          <Card key={cert.name} {...cert} />
+        ))}
+      </div>
     </div>
-  </div>
-);
+  );
+}

--- a/jamesduxbury/src/components/education/EducationDetail.tsx
+++ b/jamesduxbury/src/components/education/EducationDetail.tsx
@@ -1,13 +1,16 @@
 import { Widget } from '@/components/console/Widget';
 import { DegreeCard } from './DegreeCard';
 import { CertificationsBlock } from './CertificationsBlock';
-import { degrees } from '@/data/education';
+import { getDegrees } from '@/db/queries';
 
-export const EducationDetail: React.FC = () => (
-  <Widget channel="05" label="EDUCATION" count={degrees.length} id="education">
-    {degrees.map((d, i) => (
-      <DegreeCard key={d.qualification} degree={d} defaultOpen={i === 0} />
-    ))}
-    <CertificationsBlock />
-  </Widget>
-);
+export async function EducationDetail() {
+  const degrees = await getDegrees();
+  return (
+    <Widget channel="05" label="EDUCATION" count={degrees.length} id="education">
+      {degrees.map((d, i) => (
+        <DegreeCard key={d.qualification} degree={d} defaultOpen={i === 0} />
+      ))}
+      <CertificationsBlock />
+    </Widget>
+  );
+}

--- a/jamesduxbury/src/components/education/EducationSummary.tsx
+++ b/jamesduxbury/src/components/education/EducationSummary.tsx
@@ -1,22 +1,24 @@
 import Link from 'next/link';
 import { Widget } from '@/components/console/Widget';
 import { DegreeCard } from './DegreeCard';
-import { degrees } from '@/data/education';
-import { certifications } from '@/data/certifications';
+import { getCertifications, getDegrees } from '@/db/queries';
 
-export const EducationSummary: React.FC = () => (
-  <Widget channel="05" label="EDUCATION" count={degrees.length} id="education">
-    <div>
-      {degrees.map((d, i) => (
-        <DegreeCard key={d.qualification} degree={d} defaultOpen={i === 0} />
-      ))}
-    </div>
-    <Link
-      href="/education"
-      className="group flex items-center justify-between border-t border-border bg-bg/40 px-4 py-3 font-mono text-sm uppercase tracking-[0.18em] text-accent transition-colors hover:bg-accent/10 sm:px-6"
-    >
-      <span>+ {certifications.length} certifications</span>
-      <span className="transition-transform group-hover:translate-x-1">open /education →</span>
-    </Link>
-  </Widget>
-);
+export async function EducationSummary() {
+  const [degrees, certifications] = await Promise.all([getDegrees(), getCertifications()]);
+  return (
+    <Widget channel="05" label="EDUCATION" count={degrees.length} id="education">
+      <div>
+        {degrees.map((d, i) => (
+          <DegreeCard key={d.qualification} degree={d} defaultOpen={i === 0} />
+        ))}
+      </div>
+      <Link
+        href="/education"
+        className="group flex items-center justify-between border-t border-border bg-bg/40 px-4 py-3 font-mono text-sm uppercase tracking-[0.18em] text-accent transition-colors hover:bg-accent/10 sm:px-6"
+      >
+        <span>+ {certifications.length} certifications</span>
+        <span className="transition-transform group-hover:translate-x-1">open /education →</span>
+      </Link>
+    </Widget>
+  );
+}

--- a/jamesduxbury/src/components/experience/ExperienceDetail.tsx
+++ b/jamesduxbury/src/components/experience/ExperienceDetail.tsx
@@ -1,11 +1,14 @@
 import { Widget } from '@/components/console/Widget';
 import { RoleCard } from './RoleCard';
-import { roles } from '@/data/experience';
+import { getRoles } from '@/db/queries';
 
-export const ExperienceDetail: React.FC = () => (
-  <Widget channel="04" label="EXPERIENCE" count={roles.length} id="experience">
-    {roles.map((role, i) => (
-      <RoleCard key={`${role.organisation}-${role.period}`} role={role} defaultOpen={i === 0} />
-    ))}
-  </Widget>
-);
+export async function ExperienceDetail() {
+  const roles = await getRoles();
+  return (
+    <Widget channel="04" label="EXPERIENCE" count={roles.length} id="experience">
+      {roles.map((role, i) => (
+        <RoleCard key={`${role.organisation}-${role.period}`} role={role} defaultOpen={i === 0} />
+      ))}
+    </Widget>
+  );
+}

--- a/jamesduxbury/src/components/experience/ExperienceSummary.tsx
+++ b/jamesduxbury/src/components/experience/ExperienceSummary.tsx
@@ -1,21 +1,24 @@
 import Link from 'next/link';
 import { Widget } from '@/components/console/Widget';
 import { RoleCard } from './RoleCard';
-import { roles } from '@/data/experience';
+import { getRoles } from '@/db/queries';
 
-export const ExperienceSummary: React.FC = () => (
-  <Widget channel="04" label="EXPERIENCE" count={roles.length} id="experience">
-    <div>
-      {roles.map((role, i) => (
-        <RoleCard key={`${role.organisation}-${role.period}`} role={role} defaultOpen={i === 0} />
-      ))}
-    </div>
-    <Link
-      href="/experience"
-      className="group flex items-center justify-between border-t border-border bg-bg/40 px-4 py-3 font-mono text-sm uppercase tracking-[0.18em] text-accent transition-colors hover:bg-accent/10 sm:px-6"
-    >
-      <span>full history</span>
-      <span className="transition-transform group-hover:translate-x-1">open /experience →</span>
-    </Link>
-  </Widget>
-);
+export async function ExperienceSummary() {
+  const roles = await getRoles();
+  return (
+    <Widget channel="04" label="EXPERIENCE" count={roles.length} id="experience">
+      <div>
+        {roles.map((role, i) => (
+          <RoleCard key={`${role.organisation}-${role.period}`} role={role} defaultOpen={i === 0} />
+        ))}
+      </div>
+      <Link
+        href="/experience"
+        className="group flex items-center justify-between border-t border-border bg-bg/40 px-4 py-3 font-mono text-sm uppercase tracking-[0.18em] text-accent transition-colors hover:bg-accent/10 sm:px-6"
+      >
+        <span>full history</span>
+        <span className="transition-transform group-hover:translate-x-1">open /experience →</span>
+      </Link>
+    </Widget>
+  );
+}

--- a/jamesduxbury/src/components/skills/SkillsDetail.tsx
+++ b/jamesduxbury/src/components/skills/SkillsDetail.tsx
@@ -1,26 +1,29 @@
 import { Widget } from '@/components/console/Widget';
-import { skillGroups } from '@/data/skills';
+import { getSkillGroups } from '@/db/queries';
 
-export const SkillsDetail: React.FC = () => (
-  <Widget channel="03" label="SKILLS" count={skillGroups.length} id="skills">
-    <div className="divide-y divide-border">
-      {skillGroups.map((group) => (
-        <div key={group.heading} className="px-4 py-5 sm:px-6">
-          <div className="flex items-baseline justify-between gap-3">
-            <h3 className="font-mono text-sm uppercase tracking-[0.18em] text-text">
-              {group.heading}
-            </h3>
-            <span className="font-mono text-xs text-muted">{group.skills.length} items</span>
+export async function SkillsDetail() {
+  const skillGroups = await getSkillGroups();
+  return (
+    <Widget channel="03" label="SKILLS" count={skillGroups.length} id="skills">
+      <div className="divide-y divide-border">
+        {skillGroups.map((group) => (
+          <div key={group.heading} className="px-4 py-5 sm:px-6">
+            <div className="flex items-baseline justify-between gap-3">
+              <h3 className="font-mono text-sm uppercase tracking-[0.18em] text-text">
+                {group.heading}
+              </h3>
+              <span className="font-mono text-xs text-muted">{group.skills.length} items</span>
+            </div>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {group.skills.map((skill) => (
+                <span key={skill} className="skill-badge">
+                  {skill}
+                </span>
+              ))}
+            </div>
           </div>
-          <div className="mt-3 flex flex-wrap gap-2">
-            {group.skills.map((skill) => (
-              <span key={skill} className="skill-badge">
-                {skill}
-              </span>
-            ))}
-          </div>
-        </div>
-      ))}
-    </div>
-  </Widget>
-);
+        ))}
+      </div>
+    </Widget>
+  );
+}

--- a/jamesduxbury/src/components/skills/SkillsSummary.tsx
+++ b/jamesduxbury/src/components/skills/SkillsSummary.tsx
@@ -1,33 +1,36 @@
 import Link from 'next/link';
 import { Widget } from '@/components/console/Widget';
-import { skillGroups } from '@/data/skills';
+import { getSkillGroups } from '@/db/queries';
 
-export const SkillsSummary: React.FC = () => (
-  <Widget channel="03" label="SKILLS" count={skillGroups.length} id="skills">
-    <div className="divide-y divide-border">
-      {skillGroups.map((group) => (
-        <div key={group.heading} className="px-4 py-3 sm:px-6">
-          <div className="flex items-baseline justify-between gap-3">
-            <h3 className="font-mono text-xs uppercase tracking-[0.18em] text-text">
-              {group.heading}
-            </h3>
-            <span className="font-mono text-xs text-muted">
-              {group.skills.length} item{group.skills.length === 1 ? '' : 's'}
-            </span>
+export async function SkillsSummary() {
+  const skillGroups = await getSkillGroups();
+  return (
+    <Widget channel="03" label="SKILLS" count={skillGroups.length} id="skills">
+      <div className="divide-y divide-border">
+        {skillGroups.map((group) => (
+          <div key={group.heading} className="px-4 py-3 sm:px-6">
+            <div className="flex items-baseline justify-between gap-3">
+              <h3 className="font-mono text-xs uppercase tracking-[0.18em] text-text">
+                {group.heading}
+              </h3>
+              <span className="font-mono text-xs text-muted">
+                {group.skills.length} item{group.skills.length === 1 ? '' : 's'}
+              </span>
+            </div>
+            <p className="mt-1 font-mono text-xs text-muted">
+              {group.skills.slice(0, 4).join(' · ')}
+              {group.skills.length > 4 ? ` · +${group.skills.length - 4}` : ''}
+            </p>
           </div>
-          <p className="mt-1 font-mono text-xs text-muted">
-            {group.skills.slice(0, 4).join(' · ')}
-            {group.skills.length > 4 ? ` · +${group.skills.length - 4}` : ''}
-          </p>
-        </div>
-      ))}
-    </div>
-    <Link
-      href="/skills"
-      className="group flex items-center justify-between border-t border-border bg-bg/40 px-4 py-3 font-mono text-sm uppercase tracking-[0.18em] text-accent transition-colors hover:bg-accent/10 sm:px-6"
-    >
-      <span>full skill set</span>
-      <span className="transition-transform group-hover:translate-x-1">open /skills →</span>
-    </Link>
-  </Widget>
-);
+        ))}
+      </div>
+      <Link
+        href="/skills"
+        className="group flex items-center justify-between border-t border-border bg-bg/40 px-4 py-3 font-mono text-sm uppercase tracking-[0.18em] text-accent transition-colors hover:bg-accent/10 sm:px-6"
+      >
+        <span>full skill set</span>
+        <span className="transition-transform group-hover:translate-x-1">open /skills →</span>
+      </Link>
+    </Widget>
+  );
+}

--- a/jamesduxbury/src/components/work/WorkDetail.tsx
+++ b/jamesduxbury/src/components/work/WorkDetail.tsx
@@ -1,13 +1,16 @@
 import { Widget } from '@/components/console/Widget';
 import { ProjectRow } from './ProjectRow';
 import { ProjectTimeline } from './ProjectTimeline';
-import { projects } from '@/data/projects';
+import { getProjects } from '@/db/queries';
 
-export const WorkDetail: React.FC = () => (
-  <Widget channel="02" label="WORK" count={projects.length} id="work">
-    <ProjectTimeline projects={projects} />
-    {projects.map((project, i) => (
-      <ProjectRow key={project.slug} project={project} index={i} variant="detail" />
-    ))}
-  </Widget>
-);
+export async function WorkDetail() {
+  const projects = await getProjects();
+  return (
+    <Widget channel="02" label="WORK" count={projects.length} id="work">
+      <ProjectTimeline projects={projects} />
+      {projects.map((project, i) => (
+        <ProjectRow key={project.slug} project={project} index={i} variant="detail" />
+      ))}
+    </Widget>
+  );
+}

--- a/jamesduxbury/src/components/work/WorkSummary.tsx
+++ b/jamesduxbury/src/components/work/WorkSummary.tsx
@@ -1,11 +1,12 @@
 import Link from 'next/link';
 import { Widget } from '@/components/console/Widget';
 import { ProjectRow } from './ProjectRow';
-import { projects } from '@/data/projects';
+import { getProjects } from '@/db/queries';
 
 const SUMMARY_COUNT = 3;
 
-export const WorkSummary: React.FC = () => {
+export async function WorkSummary() {
+  const projects = await getProjects();
   const top = projects.slice(0, SUMMARY_COUNT);
   const remaining = projects.length - top.length;
 
@@ -25,4 +26,4 @@ export const WorkSummary: React.FC = () => {
       </Link>
     </Widget>
   );
-};
+}

--- a/jamesduxbury/src/db/env.ts
+++ b/jamesduxbury/src/db/env.ts
@@ -1,0 +1,17 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const appRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+export function loadEnvLocal(): void {
+  const envPath = join(appRoot, '.env.local');
+  if (!existsSync(envPath)) return;
+  for (const line of readFileSync(envPath, 'utf8').split('\n')) {
+    const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (match && process.env[match[1]] === undefined) {
+      // Quotes stripped to match Next.js/dotenv behaviour
+      process.env[match[1]] = match[2].trim().replace(/^(["'])(.*)\1$/, '$2');
+    }
+  }
+}

--- a/jamesduxbury/src/db/env.ts
+++ b/jamesduxbury/src/db/env.ts
@@ -4,8 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 const appRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
-export function loadEnvLocal(): void {
-  const envPath = join(appRoot, '.env.local');
+export function loadEnvLocal(envPath: string = join(appRoot, '.env.local')): void {
   if (!existsSync(envPath)) return;
   for (const line of readFileSync(envPath, 'utf8').split('\n')) {
     const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);

--- a/jamesduxbury/src/db/index.ts
+++ b/jamesduxbury/src/db/index.ts
@@ -1,0 +1,12 @@
+import { neon } from '@neondatabase/serverless';
+
+// Tagged-template queries only; the driver parameterises every interpolated value
+export function getSql() {
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    throw new Error('DATABASE_URL is not set');
+  }
+  return neon(url);
+}
+
+export type Sql = ReturnType<typeof getSql>;

--- a/jamesduxbury/src/db/migrate.ts
+++ b/jamesduxbury/src/db/migrate.ts
@@ -1,22 +1,10 @@
-import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { neon } from '@neondatabase/serverless';
+import { loadEnvLocal } from './env';
 
 const here = dirname(fileURLToPath(import.meta.url));
-const appRoot = join(here, '..', '..');
-
-function loadEnvLocal(): void {
-  const envPath = join(appRoot, '.env.local');
-  if (!existsSync(envPath)) return;
-  for (const line of readFileSync(envPath, 'utf8').split('\n')) {
-    const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
-    if (match && process.env[match[1]] === undefined) {
-      // Quotes stripped to match Next.js/dotenv behaviour
-      process.env[match[1]] = match[2].trim().replace(/^(["'])(.*)\1$/, '$2');
-    }
-  }
-}
 
 // Comments stripped first so their semicolons don't split; fine while the DDL has no function bodies.
 function statements(sqlText: string): string[] {

--- a/jamesduxbury/src/db/migrate.ts
+++ b/jamesduxbury/src/db/migrate.ts
@@ -7,7 +7,7 @@ import { loadEnvLocal } from './env';
 const here = dirname(fileURLToPath(import.meta.url));
 
 // Comments stripped first so their semicolons don't split; fine while the DDL has no function bodies.
-function statements(sqlText: string): string[] {
+export function statements(sqlText: string): string[] {
   return sqlText
     .split('\n')
     .map((line) => line.replace(/--.*$/, ''))
@@ -23,7 +23,7 @@ function migrationFiles(): string[] {
     .sort();
 }
 
-async function main(): Promise<void> {
+export async function main(mode: 'migrate' | 'push' = 'migrate'): Promise<void> {
   loadEnvLocal();
   const url = process.env.DATABASE_URL;
   if (!url) {
@@ -31,7 +31,6 @@ async function main(): Promise<void> {
     process.exit(1);
   }
   const sql = neon(url);
-  const mode = process.argv[2] === '--push' ? 'push' : 'migrate';
 
   await sql.query(`CREATE TABLE IF NOT EXISTS _migrations (
     name text PRIMARY KEY,
@@ -67,7 +66,9 @@ async function main(): Promise<void> {
   console.log(ran === 0 ? 'no pending migrations.' : `${ran} migration(s) applied.`);
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+if (process.argv[1]?.endsWith('migrate.ts')) {
+  main(process.argv[2] === '--push' ? 'push' : 'migrate').catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/jamesduxbury/src/db/migrate.ts
+++ b/jamesduxbury/src/db/migrate.ts
@@ -1,0 +1,85 @@
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { neon } from '@neondatabase/serverless';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const appRoot = join(here, '..', '..');
+
+function loadEnvLocal(): void {
+  const envPath = join(appRoot, '.env.local');
+  if (!existsSync(envPath)) return;
+  for (const line of readFileSync(envPath, 'utf8').split('\n')) {
+    const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (match && process.env[match[1]] === undefined) {
+      // Quotes stripped to match Next.js/dotenv behaviour
+      process.env[match[1]] = match[2].trim().replace(/^(["'])(.*)\1$/, '$2');
+    }
+  }
+}
+
+// Comments stripped first so their semicolons don't split; fine while the DDL has no function bodies.
+function statements(sqlText: string): string[] {
+  return sqlText
+    .split('\n')
+    .map((line) => line.replace(/--.*$/, ''))
+    .join('\n')
+    .split(';')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function migrationFiles(): string[] {
+  return readdirSync(join(here, 'migrations'))
+    .filter((f) => f.endsWith('.sql'))
+    .sort();
+}
+
+async function main(): Promise<void> {
+  loadEnvLocal();
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    console.error('DATABASE_URL is not set (env or .env.local).');
+    process.exit(1);
+  }
+  const sql = neon(url);
+  const mode = process.argv[2] === '--push' ? 'push' : 'migrate';
+
+  await sql.query(`CREATE TABLE IF NOT EXISTS _migrations (
+    name text PRIMARY KEY,
+    applied_at timestamptz NOT NULL DEFAULT now()
+  )`);
+
+  if (mode === 'push') {
+    const schema = readFileSync(join(here, 'schema.sql'), 'utf8');
+    for (const stmt of statements(schema)) {
+      await sql.query(stmt);
+    }
+    for (const file of migrationFiles()) {
+      await sql.query('INSERT INTO _migrations (name) VALUES ($1) ON CONFLICT DO NOTHING', [file]);
+    }
+    console.log('schema.sql applied; migrations marked as applied.');
+    return;
+  }
+
+  const appliedRows = (await sql.query('SELECT name FROM _migrations')) as { name: string }[];
+  const applied = new Set(appliedRows.map((r) => r.name));
+
+  let ran = 0;
+  for (const file of migrationFiles()) {
+    if (applied.has(file)) continue;
+    const text = readFileSync(join(here, 'migrations', file), 'utf8');
+    for (const stmt of statements(text)) {
+      await sql.query(stmt);
+    }
+    await sql.query('INSERT INTO _migrations (name) VALUES ($1)', [file]);
+    console.log(`applied ${file}`);
+    ran += 1;
+  }
+  console.log(ran === 0 ? 'no pending migrations.' : `${ran} migration(s) applied.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/jamesduxbury/src/db/migrations/0001_init.sql
+++ b/jamesduxbury/src/db/migrations/0001_init.sql
@@ -1,0 +1,102 @@
+CREATE TABLE IF NOT EXISTS projects (
+  id serial PRIMARY KEY,
+  slug text NOT NULL UNIQUE,
+  title text NOT NULL,
+  subtitle text NOT NULL,
+  status text NOT NULL CHECK (status IN ('live', 'dev', 'exam', 'shipped')),
+  under_exam boolean NOT NULL DEFAULT false,
+  year_start integer NOT NULL,
+  year_end integer NOT NULL,
+  tech_stack text[] NOT NULL DEFAULT '{}',
+  highlights text[] NOT NULL DEFAULT '{}',
+  -- ProjectMetric[] from src/data/projects.ts
+  metrics jsonb,
+  image_path text,
+  github_link text,
+  live_link text,
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS experience (
+  id serial PRIMARY KEY,
+  title text NOT NULL,
+  organisation text NOT NULL,
+  meta text,
+  period text NOT NULL,
+  year_start integer NOT NULL,
+  -- NULL = ongoing ("present" in the UI)
+  year_end integer,
+  bullets text[],
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (title, organisation)
+);
+
+CREATE TABLE IF NOT EXISTS education (
+  id serial PRIMARY KEY,
+  qualification text NOT NULL,
+  institution text NOT NULL,
+  period text NOT NULL,
+  year_end integer NOT NULL,
+  bullets text[],
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (qualification, institution)
+);
+
+CREATE TABLE IF NOT EXISTS certifications (
+  id serial PRIMARY KEY,
+  name text NOT NULL UNIQUE,
+  year text NOT NULL,
+  img_path text,
+  certification_link text,
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS skill_groups (
+  id serial PRIMARY KEY,
+  heading text NOT NULL UNIQUE,
+  skills text[] NOT NULL DEFAULT '{}',
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS about_paragraphs (
+  id serial PRIMARY KEY,
+  -- AboutParagraph from src/data/about.ts
+  runs jsonb NOT NULL,
+  sort_order integer NOT NULL UNIQUE,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+  id serial PRIMARY KEY,
+  name text NOT NULL,
+  email text NOT NULL,
+  message text NOT NULL,
+  read boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Deliberately no cookies, IPs, or fingerprinting
+CREATE TABLE IF NOT EXISTS page_views (
+  id bigserial PRIMARY KEY,
+  session_id text NOT NULL,
+  path text NOT NULL,
+  referrer text,
+  country text,
+  duration_ms integer,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS page_views_created_at_idx ON page_views (created_at);
+CREATE INDEX IF NOT EXISTS page_views_path_idx ON page_views (path);
+CREATE INDEX IF NOT EXISTS page_views_session_id_idx ON page_views (session_id);

--- a/jamesduxbury/src/db/queries.ts
+++ b/jamesduxbury/src/db/queries.ts
@@ -1,0 +1,114 @@
+import { getSql } from '@/db';
+import type { Project, ProjectMetric, ProjectStatus } from '@/data/projects';
+import type { Role } from '@/data/experience';
+import type { Degree } from '@/data/education';
+import type { Certification } from '@/data/certifications';
+import type { SkillGroup } from '@/data/skills';
+import type { AboutParagraph } from '@/data/about';
+
+interface ProjectRow {
+  slug: string;
+  title: string;
+  subtitle: string;
+  status: ProjectStatus;
+  under_exam: boolean;
+  year_start: number;
+  year_end: number;
+  tech_stack: string[];
+  highlights: string[];
+  metrics: ProjectMetric[] | null;
+  image_path: string | null;
+  github_link: string | null;
+  live_link: string | null;
+}
+
+interface RoleRow {
+  title: string;
+  organisation: string;
+  meta: string | null;
+  period: string;
+  year_start: number;
+  year_end: number | null;
+  bullets: string[] | null;
+}
+
+interface DegreeRow {
+  qualification: string;
+  institution: string;
+  period: string;
+  year_end: number;
+  bullets: string[] | null;
+}
+
+interface CertificationRow {
+  name: string;
+  year: string;
+  img_path: string | null;
+  certification_link: string | null;
+}
+
+export async function getProjects(): Promise<Project[]> {
+  const rows = (await getSql()`SELECT * FROM projects ORDER BY sort_order`) as ProjectRow[];
+  return rows.map((r) => ({
+    slug: r.slug,
+    title: r.title,
+    subtitle: r.subtitle,
+    status: r.status,
+    underExam: r.under_exam,
+    yearStart: r.year_start,
+    yearEnd: r.year_end,
+    techStack: r.tech_stack,
+    highlights: r.highlights,
+    metrics: r.metrics ?? undefined,
+    imagePath: r.image_path ?? undefined,
+    githubLink: r.github_link ?? undefined,
+    liveLink: r.live_link ?? undefined,
+  }));
+}
+
+export async function getRoles(): Promise<Role[]> {
+  const rows = (await getSql()`SELECT * FROM experience ORDER BY sort_order`) as RoleRow[];
+  return rows.map((r) => ({
+    title: r.title,
+    organisation: r.organisation,
+    meta: r.meta ?? undefined,
+    period: r.period,
+    yearStart: r.year_start,
+    yearEnd: r.year_end ?? 'present',
+    bullets: r.bullets ?? undefined,
+  }));
+}
+
+export async function getDegrees(): Promise<Degree[]> {
+  const rows = (await getSql()`SELECT * FROM education ORDER BY sort_order`) as DegreeRow[];
+  return rows.map((r) => ({
+    qualification: r.qualification,
+    institution: r.institution,
+    period: r.period,
+    yearEnd: r.year_end,
+    bullets: r.bullets ?? undefined,
+  }));
+}
+
+export async function getCertifications(): Promise<Certification[]> {
+  const rows =
+    (await getSql()`SELECT * FROM certifications ORDER BY sort_order`) as CertificationRow[];
+  return rows.map((r) => ({
+    name: r.name,
+    year: r.year,
+    imgPath: r.img_path ?? undefined,
+    certificationLink: r.certification_link ?? undefined,
+  }));
+}
+
+export async function getSkillGroups(): Promise<SkillGroup[]> {
+  const rows = (await getSql()`SELECT * FROM skill_groups ORDER BY sort_order`) as SkillGroup[];
+  return rows.map((r) => ({ heading: r.heading, skills: r.skills }));
+}
+
+export async function getAboutParagraphs(): Promise<AboutParagraph[]> {
+  const rows = (await getSql()`SELECT runs FROM about_paragraphs ORDER BY sort_order`) as {
+    runs: AboutParagraph;
+  }[];
+  return rows.map((r) => r.runs);
+}

--- a/jamesduxbury/src/db/schema.sql
+++ b/jamesduxbury/src/db/schema.sql
@@ -1,0 +1,102 @@
+CREATE TABLE IF NOT EXISTS projects (
+  id serial PRIMARY KEY,
+  slug text NOT NULL UNIQUE,
+  title text NOT NULL,
+  subtitle text NOT NULL,
+  status text NOT NULL CHECK (status IN ('live', 'dev', 'exam', 'shipped')),
+  under_exam boolean NOT NULL DEFAULT false,
+  year_start integer NOT NULL,
+  year_end integer NOT NULL,
+  tech_stack text[] NOT NULL DEFAULT '{}',
+  highlights text[] NOT NULL DEFAULT '{}',
+  -- ProjectMetric[] from src/data/projects.ts
+  metrics jsonb,
+  image_path text,
+  github_link text,
+  live_link text,
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS experience (
+  id serial PRIMARY KEY,
+  title text NOT NULL,
+  organisation text NOT NULL,
+  meta text,
+  period text NOT NULL,
+  year_start integer NOT NULL,
+  -- NULL = ongoing ("present" in the UI)
+  year_end integer,
+  bullets text[],
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (title, organisation)
+);
+
+CREATE TABLE IF NOT EXISTS education (
+  id serial PRIMARY KEY,
+  qualification text NOT NULL,
+  institution text NOT NULL,
+  period text NOT NULL,
+  year_end integer NOT NULL,
+  bullets text[],
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (qualification, institution)
+);
+
+CREATE TABLE IF NOT EXISTS certifications (
+  id serial PRIMARY KEY,
+  name text NOT NULL UNIQUE,
+  year text NOT NULL,
+  img_path text,
+  certification_link text,
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS skill_groups (
+  id serial PRIMARY KEY,
+  heading text NOT NULL UNIQUE,
+  skills text[] NOT NULL DEFAULT '{}',
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS about_paragraphs (
+  id serial PRIMARY KEY,
+  -- AboutParagraph from src/data/about.ts
+  runs jsonb NOT NULL,
+  sort_order integer NOT NULL UNIQUE,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+  id serial PRIMARY KEY,
+  name text NOT NULL,
+  email text NOT NULL,
+  message text NOT NULL,
+  read boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Deliberately no cookies, IPs, or fingerprinting
+CREATE TABLE IF NOT EXISTS page_views (
+  id bigserial PRIMARY KEY,
+  session_id text NOT NULL,
+  path text NOT NULL,
+  referrer text,
+  country text,
+  duration_ms integer,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS page_views_created_at_idx ON page_views (created_at);
+CREATE INDEX IF NOT EXISTS page_views_path_idx ON page_views (path);
+CREATE INDEX IF NOT EXISTS page_views_session_id_idx ON page_views (session_id);

--- a/jamesduxbury/src/db/seed.ts
+++ b/jamesduxbury/src/db/seed.ts
@@ -1,0 +1,74 @@
+import type { NeonQueryFunction } from '@neondatabase/serverless';
+import { projects } from '@/data/projects';
+import { roles } from '@/data/experience';
+import { degrees } from '@/data/education';
+import { certifications } from '@/data/certifications';
+import { skillGroups } from '@/data/skills';
+import { aboutParagraphs } from '@/data/about';
+
+// Insert-if-missing only: reseeding must never overwrite admin edits
+export async function seed(sql: NeonQueryFunction<false, false>): Promise<Record<string, string>> {
+  for (const [i, p] of projects.entries()) {
+    await sql`
+      INSERT INTO projects (slug, title, subtitle, status, under_exam, year_start, year_end,
+        tech_stack, highlights, metrics, image_path, github_link, live_link, sort_order)
+      VALUES (${p.slug}, ${p.title}, ${p.subtitle}, ${p.status}, ${p.underExam ?? false},
+        ${p.yearStart}, ${p.yearEnd}, ${p.techStack}, ${p.highlights},
+        ${p.metrics ? JSON.stringify(p.metrics) : null}, ${p.imagePath ?? null},
+        ${p.githubLink ?? null}, ${p.liveLink ?? null}, ${i})
+      ON CONFLICT (slug) DO NOTHING
+    `;
+  }
+
+  for (const [i, r] of roles.entries()) {
+    await sql`
+      INSERT INTO experience (title, organisation, meta, period, year_start, year_end, bullets, sort_order)
+      VALUES (${r.title}, ${r.organisation}, ${r.meta ?? null}, ${r.period}, ${r.yearStart},
+        ${r.yearEnd === 'present' ? null : r.yearEnd}, ${r.bullets ?? null}, ${i})
+      ON CONFLICT (title, organisation) DO NOTHING
+    `;
+  }
+
+  for (const [i, d] of degrees.entries()) {
+    await sql`
+      INSERT INTO education (qualification, institution, period, year_end, bullets, sort_order)
+      VALUES (${d.qualification}, ${d.institution}, ${d.period}, ${d.yearEnd}, ${d.bullets ?? null}, ${i})
+      ON CONFLICT (qualification, institution) DO NOTHING
+    `;
+  }
+
+  for (const [i, c] of certifications.entries()) {
+    await sql`
+      INSERT INTO certifications (name, year, img_path, certification_link, sort_order)
+      VALUES (${c.name}, ${c.year}, ${c.imgPath ?? null}, ${c.certificationLink ?? null}, ${i})
+      ON CONFLICT (name) DO NOTHING
+    `;
+  }
+
+  for (const [i, g] of skillGroups.entries()) {
+    await sql`
+      INSERT INTO skill_groups (heading, skills, sort_order)
+      VALUES (${g.heading}, ${g.skills}, ${i})
+      ON CONFLICT (heading) DO NOTHING
+    `;
+  }
+
+  for (const [i, runs] of aboutParagraphs.entries()) {
+    await sql`
+      INSERT INTO about_paragraphs (runs, sort_order)
+      VALUES (${JSON.stringify(runs)}, ${i})
+      ON CONFLICT (sort_order) DO NOTHING
+    `;
+  }
+
+  const counts = (await sql`
+    SELECT
+      (SELECT count(*) FROM projects) AS projects,
+      (SELECT count(*) FROM experience) AS experience,
+      (SELECT count(*) FROM education) AS education,
+      (SELECT count(*) FROM certifications) AS certifications,
+      (SELECT count(*) FROM skill_groups) AS skill_groups,
+      (SELECT count(*) FROM about_paragraphs) AS about_paragraphs
+  `) as Record<string, string>[];
+  return counts[0];
+}

--- a/jamesduxbury/src/lib/site.ts
+++ b/jamesduxbury/src/lib/site.ts
@@ -1,6 +1,6 @@
 /** Canonical site origin, overridable per environment. Trailing slashes are stripped. */
 export const SITE_URL = (
-  process.env.NEXT_PUBLIC_SITE_URL ?? 'https://jamesduxbury-dot-com.vercel.app'
+  process.env.NEXT_PUBLIC_SITE_URL || 'https://jamesduxbury-dot-com.vercel.app'
 ).replace(/\/+$/, '');
 
 /** Bare hostname of the canonical origin, for display (e.g. the OG card footer). */

--- a/jamesduxbury/tests/api-contact.test.ts
+++ b/jamesduxbury/tests/api-contact.test.ts
@@ -1,0 +1,69 @@
+import { neon } from '@neondatabase/serverless';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sendMail = vi.fn();
+vi.mock('nodemailer', () => ({
+  default: { createTransport: () => ({ sendMail }) },
+}));
+
+import { POST } from '../src/app/api/contact/route';
+
+const sql = neon(process.env.DATABASE_URL!);
+const marker = `vitest-${Date.now()}@example.com`;
+
+function request(body: unknown): Request {
+  return new Request('http://localhost/api/contact', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  sendMail.mockReset().mockResolvedValue(undefined);
+});
+
+afterAll(async () => {
+  await sql`DELETE FROM messages WHERE email = ${marker}`;
+});
+
+describe('POST /api/contact', () => {
+  it('stores the message and sends the email', async () => {
+    const res = await POST(request({ name: 'Vitest', email: marker, message: 'hello there' }));
+    expect(res.status).toBe(200);
+    expect(sendMail).toHaveBeenCalledTimes(1);
+
+    const rows = await sql`SELECT name, message, read FROM messages WHERE email = ${marker}`;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ name: 'Vitest', message: 'hello there', read: false });
+  });
+
+  it('keeps the message when the email transport fails', async () => {
+    sendMail.mockRejectedValueOnce(new Error('smtp down'));
+    const res = await POST(request({ name: 'Vitest', email: marker, message: 'survives smtp' }));
+    expect(res.status).toBe(500);
+
+    const rows = await sql`SELECT 1 FROM messages WHERE email = ${marker} AND message = 'survives smtp'`;
+    expect(rows).toHaveLength(1);
+  });
+
+  it.each([
+    [{}],
+    [{ name: 'a', email: marker }],
+    [{ name: '', email: marker, message: 'x' }],
+    [{ name: 'a', email: 'not-an-email', message: 'x' }],
+    [{ name: 'a'.repeat(201), email: marker, message: 'x' }],
+    [{ name: 'a', email: marker, message: 'x'.repeat(5001) }],
+  ])('rejects invalid payload and stores nothing', async (body) => {
+    const before = await sql`SELECT count(*) AS n FROM messages`;
+    expect((await POST(request(body))).status).toBe(400);
+    expect(sendMail).not.toHaveBeenCalled();
+    const after = await sql`SELECT count(*) AS n FROM messages`;
+    expect(after[0].n).toBe(before[0].n);
+  });
+
+  it('rejects malformed JSON', async () => {
+    const res = await POST(new Request('http://localhost/api/contact', { method: 'POST', body: '{' }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/jamesduxbury/tests/api-contact.test.ts
+++ b/jamesduxbury/tests/api-contact.test.ts
@@ -6,6 +6,18 @@ vi.mock('nodemailer', () => ({
   default: { createTransport: () => ({ sendMail }) },
 }));
 
+// Lets individual tests simulate the messages insert failing
+const dbDown = { value: false };
+vi.mock('@/db', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../src/db')>();
+  return {
+    getSql: () => {
+      if (dbDown.value) throw new Error('db down');
+      return mod.getSql();
+    },
+  };
+});
+
 import { POST } from '../src/app/api/contact/route';
 
 const sql = neon(process.env.DATABASE_URL!);
@@ -21,6 +33,7 @@ function request(body: unknown): Request {
 
 beforeEach(() => {
   sendMail.mockReset().mockResolvedValue(undefined);
+  dbDown.value = false;
 });
 
 afterAll(async () => {
@@ -38,13 +51,31 @@ describe('POST /api/contact', () => {
     expect(rows[0]).toMatchObject({ name: 'Vitest', message: 'hello there', read: false });
   });
 
-  it('keeps the message when the email transport fails', async () => {
+  it('succeeds without email when the message is stored', async () => {
     sendMail.mockRejectedValueOnce(new Error('smtp down'));
     const res = await POST(request({ name: 'Vitest', email: marker, message: 'survives smtp' }));
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(200);
 
     const rows = await sql`SELECT 1 FROM messages WHERE email = ${marker} AND message = 'survives smtp'`;
     expect(rows).toHaveLength(1);
+  });
+
+  it('succeeds without storage when the email is sent', async () => {
+    dbDown.value = true;
+    const res = await POST(request({ name: 'Vitest', email: marker, message: 'email only' }));
+    expect(res.status).toBe(200);
+    expect(sendMail).toHaveBeenCalledTimes(1);
+    dbDown.value = false;
+
+    const rows = await sql`SELECT 1 FROM messages WHERE email = ${marker} AND message = 'email only'`;
+    expect(rows).toHaveLength(0);
+  });
+
+  it('fails only when both channels fail', async () => {
+    dbDown.value = true;
+    sendMail.mockRejectedValueOnce(new Error('smtp down'));
+    const res = await POST(request({ name: 'Vitest', email: marker, message: 'all down' }));
+    expect(res.status).toBe(500);
   });
 
   it.each([

--- a/jamesduxbury/tests/api-visit.test.ts
+++ b/jamesduxbury/tests/api-visit.test.ts
@@ -1,0 +1,84 @@
+import { randomUUID } from 'node:crypto';
+import { neon } from '@neondatabase/serverless';
+import { afterAll, describe, expect, it } from 'vitest';
+import { POST } from '../src/app/api/visit/route';
+
+const sql = neon(process.env.DATABASE_URL!);
+const sessionId = randomUUID();
+
+function request(body: unknown, headers: Record<string, string> = {}): Request {
+  return new Request('http://localhost/api/visit', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+afterAll(async () => {
+  await sql`DELETE FROM page_views WHERE session_id = ${sessionId}`;
+});
+
+describe('POST /api/visit', () => {
+  it('records a view and returns a numeric id', async () => {
+    const res = await POST(
+      request(
+        { sessionId, path: '/work', referrer: 'https://example.com/' },
+        { 'x-vercel-ip-country': 'GB' },
+      ),
+    );
+    expect(res.status).toBe(200);
+    const { id } = await res.json();
+    expect(typeof id).toBe('number');
+
+    const [row] = await sql`SELECT * FROM page_views WHERE id = ${id}`;
+    expect(row.session_id).toBe(sessionId);
+    expect(row.path).toBe('/work');
+    expect(row.referrer).toBe('https://example.com/');
+    expect(row.country).toBe('GB');
+    expect(row.duration_ms).toBeNull();
+  });
+
+  it('records duration once and ignores later overwrites', async () => {
+    const { id } = await (await POST(request({ sessionId, path: '/about' }))).json();
+
+    expect((await POST(request({ id, durationMs: 1234 }))).status).toBe(204);
+    expect((await POST(request({ id, durationMs: 9999 }))).status).toBe(204);
+
+    const [row] = await sql`SELECT duration_ms FROM page_views WHERE id = ${id}`;
+    expect(row.duration_ms).toBe(1234);
+  });
+
+  it('caps implausible durations', async () => {
+    const { id } = await (await POST(request({ sessionId, path: '/skills' }))).json();
+    await POST(request({ id, durationMs: 999_999_999_999 }));
+    const [row] = await sql`SELECT duration_ms FROM page_views WHERE id = ${id}`;
+    expect(row.duration_ms).toBe(6 * 60 * 60 * 1000);
+  });
+
+  it('skips bot user agents without writing', async () => {
+    const before = await sql`SELECT count(*) AS n FROM page_views WHERE session_id = ${sessionId}`;
+    const res = await POST(
+      request({ sessionId, path: '/' }, { 'user-agent': 'Mozilla/5.0 (compatible; Googlebot/2.1)' }),
+    );
+    expect(res.status).toBe(204);
+    const after = await sql`SELECT count(*) AS n FROM page_views WHERE session_id = ${sessionId}`;
+    expect(after[0].n).toBe(before[0].n);
+  });
+
+  it.each([
+    [{ sessionId: 'not-a-uuid', path: '/' }],
+    [{ sessionId: randomUUID(), path: 'no-leading-slash' }],
+    [{ sessionId: randomUUID(), path: '/' + 'x'.repeat(300) }],
+    [{ id: 1, durationMs: -5 }],
+    [{ id: 'one', durationMs: 5 }],
+  ])('rejects invalid payload %j', async (body) => {
+    expect((await POST(request(body))).status).toBe(400);
+  });
+
+  it('rejects malformed JSON', async () => {
+    const res = await POST(
+      new Request('http://localhost/api/visit', { method: 'POST', body: 'not json' }),
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/jamesduxbury/tests/api-visit.test.ts
+++ b/jamesduxbury/tests/api-visit.test.ts
@@ -28,14 +28,23 @@ describe('POST /api/visit', () => {
     );
     expect(res.status).toBe(200);
     const { id } = await res.json();
-    expect(typeof id).toBe('number');
+    expect(id).toMatch(/^\d+$/);
 
-    const [row] = await sql`SELECT * FROM page_views WHERE id = ${id}`;
+    const [row] = await sql`SELECT * FROM page_views WHERE id = ${id}::bigint`;
     expect(row.session_id).toBe(sessionId);
     expect(row.path).toBe('/work');
     expect(row.referrer).toBe('https://example.com/');
     expect(row.country).toBe('GB');
     expect(row.duration_ms).toBeNull();
+  });
+
+  it('discards a malformed country header', async () => {
+    const res = await POST(
+      request({ sessionId, path: '/contact' }, { 'x-vercel-ip-country': 'not-a-country-code' }),
+    );
+    const { id } = await res.json();
+    const [row] = await sql`SELECT country FROM page_views WHERE id = ${id}::bigint`;
+    expect(row.country).toBeNull();
   });
 
   it('records duration once and ignores later overwrites', async () => {
@@ -44,14 +53,14 @@ describe('POST /api/visit', () => {
     expect((await POST(request({ id, durationMs: 1234 }))).status).toBe(204);
     expect((await POST(request({ id, durationMs: 9999 }))).status).toBe(204);
 
-    const [row] = await sql`SELECT duration_ms FROM page_views WHERE id = ${id}`;
+    const [row] = await sql`SELECT duration_ms FROM page_views WHERE id = ${id}::bigint`;
     expect(row.duration_ms).toBe(1234);
   });
 
   it('caps implausible durations', async () => {
     const { id } = await (await POST(request({ sessionId, path: '/skills' }))).json();
     await POST(request({ id, durationMs: 999_999_999_999 }));
-    const [row] = await sql`SELECT duration_ms FROM page_views WHERE id = ${id}`;
+    const [row] = await sql`SELECT duration_ms FROM page_views WHERE id = ${id}::bigint`;
     expect(row.duration_ms).toBe(6 * 60 * 60 * 1000);
   });
 
@@ -69,7 +78,8 @@ describe('POST /api/visit', () => {
     [{ sessionId: 'not-a-uuid', path: '/' }],
     [{ sessionId: randomUUID(), path: 'no-leading-slash' }],
     [{ sessionId: randomUUID(), path: '/' + 'x'.repeat(300) }],
-    [{ id: 1, durationMs: -5 }],
+    [{ id: '1', durationMs: -5 }],
+    [{ id: 1, durationMs: 5 }],
     [{ id: 'one', durationMs: 5 }],
   ])('rejects invalid payload %j', async (body) => {
     expect((await POST(request(body))).status).toBe(400);

--- a/jamesduxbury/tests/components.dom.test.tsx
+++ b/jamesduxbury/tests/components.dom.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { WorkDetail } from '../src/components/work/WorkDetail';
+import { ExperienceDetail } from '../src/components/experience/ExperienceDetail';
+import { EducationSummary } from '../src/components/education/EducationSummary';
+import { CertificationsBlock } from '../src/components/education/CertificationsBlock';
+import { SkillsDetail } from '../src/components/skills/SkillsDetail';
+import { AboutDetail } from '../src/components/about/AboutDetail';
+import { projects } from '../src/data/projects';
+import { roles } from '../src/data/experience';
+import { degrees } from '../src/data/education';
+import { certifications } from '../src/data/certifications';
+import { skillGroups } from '../src/data/skills';
+
+describe('detail components render seeded DB content', () => {
+  it('WorkDetail lists every project', async () => {
+    render(await WorkDetail());
+    for (const p of projects) {
+      expect(screen.getAllByText(p.title).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('ExperienceDetail lists every role', async () => {
+    render(await ExperienceDetail());
+    for (const r of roles) {
+      expect(screen.getAllByText(r.organisation).length).toBeGreaterThan(0);
+    }
+  });
+
+  // EducationDetail nests the async CertificationsBlock, which client-side React
+  // cannot resolve in jsdom, so its halves are rendered separately
+  it('EducationSummary lists every degree', async () => {
+    render(await EducationSummary());
+    for (const d of degrees) {
+      expect(screen.getAllByText(d.qualification).length).toBeGreaterThan(0);
+    }
+    expect(screen.getByText(`+ ${certifications.length} certifications`)).toBeInTheDocument();
+  });
+
+  it('CertificationsBlock lists every certification', async () => {
+    render(await CertificationsBlock());
+    for (const c of certifications) {
+      expect(screen.getAllByText(c.name).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('SkillsDetail lists every skill group', async () => {
+    render(await SkillsDetail());
+    for (const g of skillGroups) {
+      expect(screen.getAllByText(g.heading).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('AboutDetail renders styled runs from jsonb', async () => {
+    render(await AboutDetail());
+    const strong = screen.getByText('Artificial Intelligence and application security');
+    expect(strong.tagName).toBe('STRONG');
+  });
+});

--- a/jamesduxbury/tests/db-env.test.ts
+++ b/jamesduxbury/tests/db-env.test.ts
@@ -1,0 +1,46 @@
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { loadEnvLocal } from '../src/db/env';
+
+const dir = mkdtempSync(join(tmpdir(), 'env-test-'));
+const file = join(dir, '.env.local');
+
+afterEach(() => {
+  delete process.env.ENV_TEST_PLAIN;
+  delete process.env.ENV_TEST_QUOTED;
+  delete process.env.ENV_TEST_SINGLE;
+  delete process.env.ENV_TEST_EXISTING;
+});
+
+describe('loadEnvLocal', () => {
+  it('loads plain and quote-wrapped values', () => {
+    writeFileSync(
+      file,
+      'ENV_TEST_PLAIN=abc\nENV_TEST_QUOTED="postgresql://u:p@host/db?x=1"\nENV_TEST_SINGLE=\'single\'\n',
+    );
+    loadEnvLocal(file);
+    expect(process.env.ENV_TEST_PLAIN).toBe('abc');
+    expect(process.env.ENV_TEST_QUOTED).toBe('postgresql://u:p@host/db?x=1');
+    expect(process.env.ENV_TEST_SINGLE).toBe('single');
+  });
+
+  it('does not override variables already set in the environment', () => {
+    process.env.ENV_TEST_EXISTING = 'real';
+    writeFileSync(file, 'ENV_TEST_EXISTING=fromfile\n');
+    loadEnvLocal(file);
+    expect(process.env.ENV_TEST_EXISTING).toBe('real');
+  });
+
+  it('ignores comments, blanks and malformed lines', () => {
+    writeFileSync(file, '# comment\n\nnot a pair\nENV_TEST_PLAIN=ok\n');
+    loadEnvLocal(file);
+    expect(process.env.ENV_TEST_PLAIN).toBe('ok');
+  });
+
+  it('is a no-op for a missing file', () => {
+    rmSync(file);
+    expect(() => loadEnvLocal(file)).not.toThrow();
+  });
+});

--- a/jamesduxbury/tests/db-index.test.ts
+++ b/jamesduxbury/tests/db-index.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getSql } from '../src/db';
+import { main } from '../src/db/migrate';
+
+const saved = process.env.DATABASE_URL;
+
+afterEach(() => {
+  process.env.DATABASE_URL = saved;
+});
+
+describe('getSql', () => {
+  it('throws without DATABASE_URL', () => {
+    delete process.env.DATABASE_URL;
+    expect(() => getSql()).toThrow('DATABASE_URL is not set');
+  });
+
+  it('returns a queryable client', async () => {
+    const sql = getSql();
+    const [row] = await sql`SELECT 1 AS one`;
+    expect(row.one).toBe(1);
+  });
+});
+
+describe('migrate main', () => {
+  it('migrate mode is a no-op when up to date', async () => {
+    await expect(main('migrate')).resolves.toBeUndefined();
+  });
+
+  it('push mode reapplies the idempotent schema safely', async () => {
+    await expect(main('push')).resolves.toBeUndefined();
+  });
+});

--- a/jamesduxbury/tests/migrate.test.ts
+++ b/jamesduxbury/tests/migrate.test.ts
@@ -1,0 +1,28 @@
+import { execSync } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+import { statements } from '../src/db/migrate';
+
+describe('statements', () => {
+  it('splits on semicolons and trims whitespace', () => {
+    expect(statements('CREATE TABLE a (id int);\nCREATE TABLE b (id int);')).toEqual([
+      'CREATE TABLE a (id int)',
+      'CREATE TABLE b (id int)',
+    ]);
+  });
+
+  it('ignores semicolons inside line comments', () => {
+    const sql = '-- has; a semicolon\nCREATE TABLE a (id int); -- and; another\n';
+    expect(statements(sql)).toEqual(['CREATE TABLE a (id int)']);
+  });
+
+  it('drops empty fragments', () => {
+    expect(statements(';;\n  ;\n')).toEqual([]);
+  });
+});
+
+describe('db:migrate', () => {
+  it('is a no-op when all migrations are applied', () => {
+    const out = execSync('npm run db:migrate', { encoding: 'utf8' });
+    expect(out).toContain('no pending migrations.');
+  });
+});

--- a/jamesduxbury/tests/seed-and-queries.test.ts
+++ b/jamesduxbury/tests/seed-and-queries.test.ts
@@ -1,0 +1,71 @@
+import { neon } from '@neondatabase/serverless';
+import { describe, expect, it } from 'vitest';
+import { seed } from '../src/db/seed';
+import {
+  getAboutParagraphs,
+  getCertifications,
+  getDegrees,
+  getProjects,
+  getRoles,
+  getSkillGroups,
+} from '../src/db/queries';
+import { projects } from '../src/data/projects';
+import { roles } from '../src/data/experience';
+import { degrees } from '../src/data/education';
+import { certifications } from '../src/data/certifications';
+import { skillGroups } from '../src/data/skills';
+import { aboutParagraphs } from '../src/data/about';
+
+const sql = neon(process.env.DATABASE_URL!);
+
+describe('seed', () => {
+  it('is idempotent: two runs leave identical counts', async () => {
+    const first = await seed(sql);
+    const second = await seed(sql);
+    expect(second).toEqual(first);
+    expect(first).toEqual({
+      projects: String(projects.length),
+      experience: String(roles.length),
+      education: String(degrees.length),
+      certifications: String(certifications.length),
+      skill_groups: String(skillGroups.length),
+      about_paragraphs: String(aboutParagraphs.length),
+    });
+  });
+
+  it('does not overwrite existing rows', async () => {
+    await sql`UPDATE projects SET subtitle = 'edited via admin' WHERE slug = ${projects[0].slug}`;
+    await seed(sql);
+    const [row] = await sql`SELECT subtitle FROM projects WHERE slug = ${projects[0].slug}`;
+    expect(row.subtitle).toBe('edited via admin');
+    await sql`UPDATE projects SET subtitle = ${projects[0].subtitle} WHERE slug = ${projects[0].slug}`;
+  });
+});
+
+describe('queries round-trip the seeded src/data shapes exactly', () => {
+  it('projects', async () => {
+    expect(await getProjects()).toEqual(
+      projects.map((p) => ({ ...p, underExam: p.underExam ?? false })),
+    );
+  });
+
+  it('roles, including present-role mapping', async () => {
+    expect(await getRoles()).toEqual(roles);
+  });
+
+  it('degrees', async () => {
+    expect(await getDegrees()).toEqual(degrees);
+  });
+
+  it('certifications', async () => {
+    expect(await getCertifications()).toEqual(certifications);
+  });
+
+  it('skill groups', async () => {
+    expect(await getSkillGroups()).toEqual(skillGroups);
+  });
+
+  it('about paragraphs', async () => {
+    expect(await getAboutParagraphs()).toEqual(aboutParagraphs);
+  });
+});

--- a/jamesduxbury/tests/setup.ts
+++ b/jamesduxbury/tests/setup.ts
@@ -1,7 +1,11 @@
 import '@testing-library/jest-dom/vitest';
+import { neonConfig } from '@neondatabase/serverless';
 import { loadEnvLocal } from '../src/db/env';
 
 loadEnvLocal();
+
+// jsdom looks like a browser to the driver; the warning does not apply to tests
+neonConfig.disableWarningInBrowsers = true;
 
 // jsdom lacks IntersectionObserver, which framer-motion's whileInView needs
 if (typeof window !== 'undefined' && !window.IntersectionObserver) {

--- a/jamesduxbury/tests/setup.ts
+++ b/jamesduxbury/tests/setup.ts
@@ -1,0 +1,19 @@
+import '@testing-library/jest-dom/vitest';
+import { loadEnvLocal } from '../src/db/env';
+
+loadEnvLocal();
+
+// jsdom lacks IntersectionObserver, which framer-motion's whileInView needs
+if (typeof window !== 'undefined' && !window.IntersectionObserver) {
+  window.IntersectionObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return [];
+    }
+    readonly root = null;
+    readonly rootMargin = '';
+    readonly thresholds = [];
+  };
+}

--- a/jamesduxbury/tests/site-meta.test.ts
+++ b/jamesduxbury/tests/site-meta.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe('site config', () => {
+  it('strips trailing slashes from NEXT_PUBLIC_SITE_URL', async () => {
+    vi.stubEnv('NEXT_PUBLIC_SITE_URL', 'https://example.com///');
+    const { SITE_URL, SITE_HOST } = await import('../src/lib/site');
+    expect(SITE_URL).toBe('https://example.com');
+    expect(SITE_HOST).toBe('example.com');
+  });
+
+  it('falls back to the vercel domain', async () => {
+    vi.stubEnv('NEXT_PUBLIC_SITE_URL', '');
+    const { SITE_URL } = await import('../src/lib/site');
+    expect(SITE_URL).toBe('https://jamesduxbury-dot-com.vercel.app');
+  });
+});
+
+describe('sitemap and robots', () => {
+  it('covers every public route with no double slashes', async () => {
+    const { default: sitemap } = await import('../src/app/sitemap');
+    const { SITE_ROUTES } = await import('../src/lib/site');
+    const entries = sitemap();
+    expect(entries).toHaveLength(SITE_ROUTES.length);
+    for (const e of entries) {
+      expect(e.url).not.toMatch(/[^:]\/\//);
+    }
+  });
+
+  it('disallows /api/ and /admin/ and links the sitemap', async () => {
+    const { default: robots } = await import('../src/app/robots');
+    const r = robots();
+    expect(r.rules).toMatchObject({ disallow: ['/api/', '/admin/'] });
+    expect(r.sitemap).toMatch(/\/sitemap\.xml$/);
+  });
+});

--- a/jamesduxbury/tests/ui.dom.test.tsx
+++ b/jamesduxbury/tests/ui.dom.test.tsx
@@ -1,0 +1,234 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let pathname: string | null = '/work';
+vi.mock('next/navigation', () => ({ usePathname: () => pathname }));
+
+import { Entry } from '../src/components/Entry';
+import { Footer } from '../src/components/Footer';
+import { StatusBar } from '../src/components/console/StatusBar';
+import { MetricBar } from '../src/components/work/MetricBar';
+import { ProjectRow } from '../src/components/work/ProjectRow';
+import { DegreeCard } from '../src/components/education/DegreeCard';
+import { ContactForm } from '../src/components/contact/ContactForm';
+import { ContactChannels } from '../src/components/contact/ContactChannels';
+import { WorkSummary } from '../src/components/work/WorkSummary';
+import { ExperienceSummary } from '../src/components/experience/ExperienceSummary';
+import { SkillsSummary } from '../src/components/skills/SkillsSummary';
+import { AboutSummary } from '../src/components/about/AboutSummary';
+import { EducationDetail } from '../src/components/education/EducationDetail';
+import { degrees } from '../src/data/education';
+import type { Project } from '../src/data/projects';
+
+// Stubbed per-describe only: the neon HTTP driver also uses fetch, so a global
+// stub would sever the DB-backed component tests
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  pathname = '/work';
+});
+
+describe('summary components render DB content', () => {
+  it.each([
+    [WorkSummary, 'open /work →'],
+    [ExperienceSummary, 'open /experience →'],
+    [SkillsSummary, 'open /skills →'],
+    [AboutSummary, 'open /about →'],
+  ] as const)('%o links to its detail page', async (Component, cta) => {
+    render(await Component());
+    expect(screen.getByText(cta)).toBeInTheDocument();
+  });
+
+  it('EducationDetail composes a widget over every degree', async () => {
+    // Not rendered: it nests another async component, which jsdom client React cannot resolve
+    const element = await EducationDetail();
+    expect(element.props.count).toBe(degrees.length);
+    expect(element.props.label).toBe('EDUCATION');
+  });
+});
+
+describe('Entry', () => {
+  it('renders the entry channel header', () => {
+    render(<Entry />);
+    expect(screen.getByText(/CHANNEL 00/)).toBeInTheDocument();
+  });
+});
+
+describe('Footer', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  // Counts chosen to hit every intensity band: 0, <3, <6, <10, >=10
+  const contributions = Array.from({ length: 91 }, (_, i) => ({
+    date: `2026-0${(i % 9) + 1}-0${(i % 9) + 1}-${i}`,
+    contributionCount: [0, 2, 5, 7, 11][i % 5],
+  }));
+
+  it('renders the contribution grid across all intensity bands', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ total: {}, contributions }),
+    });
+    const { container } = render(await Footer());
+    expect(screen.getByText(/github activity/)).toBeInTheDocument();
+    const cells = [...container.querySelectorAll('span[title]')];
+    expect(cells).toHaveLength(91);
+    const tokens = new Set(cells.flatMap((c) => c.className.split(' ')));
+    for (const cls of ['bg-border/60', 'bg-accent/30', 'bg-accent/55', 'bg-accent/80', 'bg-accent']) {
+      expect(tokens).toContain(cls);
+    }
+  });
+
+  it('omits the grid when the contributions API fails', async () => {
+    fetchMock.mockResolvedValue({ ok: false });
+    render(await Footer());
+    expect(screen.queryByText(/github activity/)).toBeNull();
+  });
+
+  it('omits the grid when the contributions API is unreachable', async () => {
+    fetchMock.mockRejectedValue(new Error('offline'));
+    render(await Footer());
+    expect(screen.queryByText(/github activity/)).toBeNull();
+    expect(screen.getByText('contact form ↗')).toBeInTheDocument();
+  });
+});
+
+describe('StatusBar', () => {
+  it('marks the current route as active', () => {
+    render(<StatusBar />);
+    const active = screen
+      .getAllByRole('link', { name: 'work' })
+      .find((l) => l.getAttribute('aria-current') === 'page');
+    expect(active).toBeDefined();
+  });
+
+  it('opens and closes the mobile menu', () => {
+    render(<StatusBar />);
+    const button = screen.getByRole('button', { name: 'Open menu' });
+    fireEvent.click(button);
+    expect(screen.getAllByRole('link', { name: 'about' }).length).toBeGreaterThan(1);
+
+    fireEvent.click(screen.getAllByRole('link', { name: 'about' })[1]);
+    expect(screen.getAllByRole('link', { name: 'about' })).toHaveLength(1);
+  });
+
+  it('closes the mobile menu when resized to desktop', () => {
+    render(<StatusBar />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    window.innerWidth = 1280;
+    fireEvent(window, new Event('resize'));
+    expect(screen.getAllByRole('link', { name: 'about' })).toHaveLength(1);
+  });
+});
+
+describe('ContactForm', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  function fill() {
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'A' } });
+    fireEvent.change(screen.getByLabelText(/Email/), { target: { value: 'a@b.co' } });
+    fireEvent.change(screen.getByLabelText(/Message/), { target: { value: 'hi' } });
+  }
+
+  it('shows success and clears fields', async () => {
+    fetchMock.mockResolvedValue({ ok: true });
+    render(<ContactForm />);
+    fill();
+    fireEvent.submit(screen.getByRole('button', { name: /transmit/ }).closest('form')!);
+    await waitFor(() => expect(screen.getByText(/transmission acknowledged/)).toBeInTheDocument());
+    expect(screen.getByLabelText('Name')).toHaveValue('');
+  });
+
+  it('shows the server error message', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 400, json: async () => ({ error: 'Invalid payload' }) });
+    render(<ContactForm />);
+    fill();
+    fireEvent.submit(screen.getByRole('button', { name: /transmit/ }).closest('form')!);
+    await waitFor(() => expect(screen.getByText(/Invalid payload/)).toBeInTheDocument());
+  });
+
+  it('falls back to a status message when the error body is unreadable', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500, json: async () => Promise.reject(new Error('no body')) });
+    render(<ContactForm />);
+    fill();
+    fireEvent.submit(screen.getByRole('button', { name: /transmit/ }).closest('form')!);
+    await waitFor(() => expect(screen.getByText(/Transmission failed \(500\)/)).toBeInTheDocument());
+  });
+
+  it('shows network failures and disables the button while sending', async () => {
+    let reject: (e: Error) => void;
+    fetchMock.mockReturnValue(new Promise((_, rej) => (reject = rej)));
+    render(<ContactForm />);
+    fill();
+    fireEvent.submit(screen.getByRole('button', { name: /transmit/ }).closest('form')!);
+    await waitFor(() => expect(screen.getByRole('button', { name: /sending/ })).toBeDisabled());
+    reject!(new Error('network down'));
+    await waitFor(() => expect(screen.getByText(/network down/)).toBeInTheDocument());
+  });
+});
+
+describe('ContactChannels', () => {
+  it('renders all channels, external ones in a new tab', () => {
+    render(<ContactChannels />);
+    expect(screen.getByText('@jsduxie').nextElementSibling).toHaveAttribute('target', '_blank');
+    expect(screen.getByText('secure mailto channel')).toBeInTheDocument();
+    expect(screen.getByText('in/jamesduxbury03')).toBeInTheDocument();
+  });
+});
+
+describe('presentational edge cases', () => {
+  const base: Project = {
+    slug: 't',
+    title: 'Test Project',
+    subtitle: 'sub',
+    status: 'live',
+    yearStart: 2025,
+    yearEnd: 2025,
+    techStack: ['a', 'b', 'c', 'd', 'e'],
+    highlights: ['h1'],
+  };
+
+  it('ProjectRow renders live links and truncates compact tech stacks', () => {
+    render(<ProjectRow project={{ ...base, liveLink: 'https://x.test' }} index={0} variant="detail" />);
+    expect(screen.getByText('open live ↗')).toHaveAttribute('href', 'https://x.test');
+
+    render(<ProjectRow project={base} index={1} variant="compact" />);
+    expect(screen.getByText(/\+2$/)).toBeInTheDocument();
+  });
+
+  it('MetricBar clamps ratios into the bar range', () => {
+    const { container } = render(
+      <MetricBar
+        metrics={[
+          { label: 'over', value: 'x', ratio: 1.5 },
+          { label: 'under', value: 'y', ratio: -0.2 },
+        ]}
+      />,
+    );
+    const widths = [...container.querySelectorAll('[style]')].map(
+      (el) => (el as HTMLElement).style.width,
+    );
+    expect(widths).toContain('100%');
+    expect(widths).toContain('0%');
+  });
+
+  it('DegreeCard renders bullet-less degrees as a static row', () => {
+    render(<DegreeCard degree={{ qualification: 'Q', institution: 'I', period: 'P', yearEnd: 2020 }} />);
+    expect(screen.getByText('▸')).toBeInTheDocument();
+  });
+
+  it('DegreeCard collapses and expands bulleted degrees', () => {
+    render(<DegreeCard degree={degrees[0]} />);
+    const toggle = screen.getByRole('button');
+    fireEvent.click(toggle);
+    expect(screen.getAllByText(degrees[0].bullets![0]).length).toBeGreaterThan(0);
+  });
+});

--- a/jamesduxbury/tests/visit-beacon.dom.test.tsx
+++ b/jamesduxbury/tests/visit-beacon.dom.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let pathname = '/work';
+vi.mock('next/navigation', () => ({ usePathname: () => pathname }));
+
+import { VisitBeacon } from '../src/components/VisitBeacon';
+
+const fetchMock = vi.fn();
+const sendBeacon = vi.fn();
+
+beforeEach(() => {
+  pathname = '/work';
+  sessionStorage.clear();
+  fetchMock.mockReset().mockResolvedValue({ ok: true, json: async () => ({ id: 7 }) });
+  sendBeacon.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+  Object.defineProperty(navigator, 'sendBeacon', { value: sendBeacon, configurable: true });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('VisitBeacon', () => {
+  it('posts the view with a per-tab session id and external referrer', async () => {
+    render(<VisitBeacon />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.path).toBe('/work');
+    expect(body.sessionId).toBe(sessionStorage.getItem('visit-session'));
+    expect(body.sessionId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('reuses the session id and omits the referrer on subsequent views', async () => {
+    sessionStorage.setItem('visit-session', '11111111-2222-3333-4444-555555555555');
+    render(<VisitBeacon />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.sessionId).toBe('11111111-2222-3333-4444-555555555555');
+    expect(body.referrer).toBeNull();
+  });
+
+  it('sends a duration beacon when the page is hidden, once only', async () => {
+    render(<VisitBeacon />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(sendBeacon).toHaveBeenCalledTimes(1);
+    const sent = JSON.parse(await (sendBeacon.mock.calls[0][1] as Blob).text());
+    expect(sent.id).toBe(7);
+    expect(sent.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('does not track admin pages', async () => {
+    pathname = '/admin/projects';
+    render(<VisitBeacon />);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/jamesduxbury/tests/visit-beacon.dom.test.tsx
+++ b/jamesduxbury/tests/visit-beacon.dom.test.tsx
@@ -13,7 +13,7 @@ const sendBeacon = vi.fn();
 beforeEach(() => {
   pathname = '/work';
   sessionStorage.clear();
-  fetchMock.mockReset().mockResolvedValue({ ok: true, json: async () => ({ id: 7 }) });
+  fetchMock.mockReset().mockResolvedValue({ ok: true, json: async () => ({ id: '7' }) });
   sendBeacon.mockReset();
   vi.stubGlobal('fetch', fetchMock);
   Object.defineProperty(navigator, 'sendBeacon', { value: sendBeacon, configurable: true });
@@ -55,7 +55,7 @@ describe('VisitBeacon', () => {
 
     expect(sendBeacon).toHaveBeenCalledTimes(1);
     const sent = JSON.parse(await (sendBeacon.mock.calls[0][1] as Blob).text());
-    expect(sent.id).toBe(7);
+    expect(sent.id).toBe('7');
     expect(sent.durationMs).toBeGreaterThanOrEqual(0);
   });
 

--- a/jamesduxbury/vitest.config.ts
+++ b/jamesduxbury/vitest.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
   },
   test: {
     globals: true,
+    // Integration tests run against a remote Neon branch; CI runners need the headroom
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
     setupFiles: ['./tests/setup.ts'],
     include: ['tests/**/*.test.{ts,tsx}'],
     coverage: {

--- a/jamesduxbury/vitest.config.ts
+++ b/jamesduxbury/vitest.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from 'node:url';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: { '@': fileURLToPath(new URL('./src', import.meta.url)) },
+  },
+  test: {
+    globals: true,
+    setupFiles: ['./tests/setup.ts'],
+    include: ['tests/**/*.test.{ts,tsx}'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.{ts,tsx}'],
+      // Page shells and the OG card are covered by the build-time HTML diff, not unit tests
+      exclude: [
+        'src/app/**/page.tsx',
+        'src/app/layout.tsx',
+        'src/app/opengraph-image.tsx',
+        'src/data/**',
+      ],
+      thresholds: { lines: 90, functions: 90, statements: 90, branches: 85 },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Moves all site content from hard-coded TS modules to Neon Postgres and starts collecting first-party visit analytics. Public pages are now DB-backed with ISR, ready for the v2.0 admin console (#15, #16) to edit them without a code push.

## Commits

1. **Schema + migration runner** — `@neondatabase/serverless` (raw tagged-template SQL, no ORM), 8 tables (`projects`, `experience`, `education`, `certifications`, `skill_groups`, `about_paragraphs`, `messages`, `page_views`), a minimal `_migrations` runner with `db:migrate` / `db:push` scripts.
2. **Seed pipeline** — `db:seed` upserts from `src/data/*.ts` with insert-if-missing semantics: reseeding can never overwrite rows edited later via the admin console. The TS modules remain the first-boot source of truth.
3. **DB-backed pages** — 11 components became async server components reading via a typed query layer (`src/db/queries.ts`, explicit row interfaces, no `any`); all six pages use `revalidate: 60`.
4. **Analytics collection + message persistence** (#17, collection half) — invisible `VisitBeacon` posts to `/api/visit` (per-tab session UUID, referrer on first view only, exit-beacon durations, bot filtering, Vercel geo country; no cookies or IPs). Contact submissions are stored in `messages` before the email attempt, so a transport failure cannot lose them.
5. **Tests + CI** — Vitest + RTL: 74 tests across 10 files (unit, integration against the Neon dev branch, DOM). Coverage 94.9% statements / 89.9% branches / 95.5% functions / 95.9% lines with thresholds enforced in CI. The workflow runs tests with the dev-branch `DATABASE_URL`, builds migrate-first, and a manually-dispatched `populate-production` job performs the one-off prod migrate + seed (insert-if-missing as a second guard).

## UI unchanged — verified

Production builds of `main` (TS data) and this branch (DB data) produce byte-identical prerendered HTML for all 7 pages after normalising build IDs and asset hashes.

## Verification

- Migration applied to the Neon dev branch; reruns are no-ops.
- Seed run twice: identical counts; an edited row survives reseeding.
- `/api/visit` exercised end-to-end: insert, duration write-once, bot skip, validation rejections.
- Contact transport failure path proven to retain the message.
- Full gate green: prettier, typecheck, ESLint, tests with coverage thresholds, production build.

## Deployment notes

- Requires the `DATABASE_URL_DEV` (CI) and `DATABASE_URL_MAIN` (populate-production) repository secrets — after merging, trigger `populate-production` once from the Actions tab — and Vercel `DATABASE_URL` scoped per environment (Production = main branch, Preview = dev branch).
- First Vercel build migrates the target database before `next build`, fixing the earlier preview prerender failure.

Closes #14
Refs #17 (collection half; dashboard lands with #16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
