### PR TITLE
feat: github-allowlisted auth, schema-driven admin console, analytics dashboard

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,11 +38,18 @@ jobs:
         run: npm test
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL_DEV }}
+          # dummy values, no real oauth flow runs in ci
+          GITHUB_ID: ci-dummy
+          GITHUB_SECRET: ci-dummy
+          AUTH_SECRET: ci-dummy-secret-for-build-only
 
       - name: Build
         run: npm run build
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL_DEV }}
+          GITHUB_ID: ci-dummy
+          GITHUB_SECRET: ci-dummy
+          AUTH_SECRET: ci-dummy-secret-for-build-only
 
   # One-off prod population, run manually via the Actions tab after merging this PR.
   # Never triggered by pushes or PRs; the seed is also insert-if-missing as a second guard.

--- a/jamesduxbury/.env.example
+++ b/jamesduxbury/.env.example
@@ -1,3 +1,9 @@
 # Neon Postgres connection string.
 # Local dev + CI use the dev branch; Vercel production uses the main branch.
 DATABASE_URL=postgresql://user:password@host/dbname?sslmode=require
+
+# GitHub OAuth app for /admin sign-in (separate apps for prod and localhost).
+GITHUB_ID=your-oauth-app-client-id
+GITHUB_SECRET=your-oauth-app-client-secret
+# Generate with: openssl rand -base64 32
+AUTH_SECRET=random-32-byte-secret

--- a/jamesduxbury/package-lock.json
+++ b/jamesduxbury/package-lock.json
@@ -13,9 +13,11 @@
         "framer-motion": "^12.38.0",
         "geist": "^1.7.0",
         "next": "^15.5.18",
+        "next-auth": "^5.0.0-beta.31",
         "nodemailer": "^8.0.7",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -110,6 +112,35 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@auth/core": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.2.tgz",
+      "integrity": "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^7.0.7"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -1804,6 +1835,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -5370,6 +5410,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6079,6 +6128,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.31.tgz",
+      "integrity": "sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.2"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "nodemailer": "^7.0.7",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -6135,6 +6211,15 @@
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/object-assign": {
@@ -6602,6 +6687,25 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
+    "node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -8649,6 +8753,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/jamesduxbury/package.json
+++ b/jamesduxbury/package.json
@@ -23,9 +23,16 @@
     "framer-motion": "^12.38.0",
     "geist": "^1.7.0",
     "next": "^15.5.18",
+    "next-auth": "^5.0.0-beta.31",
     "nodemailer": "^8.0.7",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "zod": "^4.4.3"
+  },
+  "overrides": {
+    "next-auth": {
+      "nodemailer": "$nodemailer"
+    }
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/jamesduxbury/src/admin/actions.ts
+++ b/jamesduxbury/src/admin/actions.ts
@@ -1,0 +1,83 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { auth, isAdminSession } from '@/auth';
+import { getSql } from '@/db';
+import { SITE_ROUTES } from '@/lib/site';
+import { parseFields, type FieldDef } from './fields';
+import { getSection } from './sections';
+import { deleteRow, insertRow, makeRoomAt, updateRow } from './sql';
+
+export interface FormState {
+  message: string | null;
+  fieldErrors: Record<string, string>;
+}
+
+async function requireAdmin(): Promise<void> {
+  if (!isAdminSession(await auth())) throw new Error('Unauthorised');
+}
+
+function revalidatePublicPages(): void {
+  for (const route of SITE_ROUTES) revalidatePath(route);
+}
+
+// serialises jsonb field values to JSON strings
+function toSqlValues(fields: FieldDef[], data: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const f of fields) {
+    const value = data[f.column];
+    out[f.column] =
+      (f.type === 'metrics' || f.type === 'runs') && value !== null ? JSON.stringify(value) : value;
+  }
+  return out;
+}
+
+export async function saveItem(
+  slug: string,
+  id: number | null,
+  _prev: FormState,
+  formData: FormData,
+): Promise<FormState> {
+  await requireAdmin();
+  const section = getSection(slug);
+
+  const values = parseFields(section.fields, formData);
+  const parsed = section.schema.safeParse(values);
+  if (!parsed.success) {
+    const fieldErrors: Record<string, string> = {};
+    for (const issue of parsed.error.issues) {
+      const key = String(issue.path[0] ?? '');
+      if (key && !(key in fieldErrors)) fieldErrors[key] = issue.message;
+    }
+    return { message: 'Validation failed', fieldErrors };
+  }
+
+  try {
+    const row = toSqlValues(section.fields, parsed.data);
+    const sortOrder = row.sort_order;
+    if (typeof sortOrder === 'number') await makeRoomAt(section.table, sortOrder, id);
+    if (id === null) await insertRow(section.table, row);
+    else await updateRow(section.table, id, row);
+  } catch (err) {
+    return { message: err instanceof Error ? err.message : 'Save failed', fieldErrors: {} };
+  }
+
+  revalidatePublicPages();
+  revalidatePath(`/admin/${slug}`);
+  redirect(`/admin/${slug}`);
+}
+
+export async function deleteItem(slug: string, id: number): Promise<void> {
+  await requireAdmin();
+  const section = getSection(slug);
+  await deleteRow(section.table, id);
+  revalidatePublicPages();
+  revalidatePath(`/admin/${slug}`);
+}
+
+export async function markMessageRead(id: number): Promise<void> {
+  await requireAdmin();
+  await getSql()`UPDATE messages SET read = true WHERE id = ${id}`;
+  revalidatePath('/admin/messages');
+}

--- a/jamesduxbury/src/admin/fields.ts
+++ b/jamesduxbury/src/admin/fields.ts
@@ -1,0 +1,126 @@
+import type { AboutParagraph } from '@/data/about';
+import type { ProjectMetric } from '@/data/projects';
+import { parseRuns, serialiseRuns } from './runs';
+
+export type FieldType =
+  | 'text'
+  | 'textarea'
+  | 'bullets'
+  | 'tags'
+  | 'url'
+  | 'number'
+  | 'sort_order'
+  | 'select'
+  | 'checkbox'
+  | 'metrics'
+  | 'runs';
+
+export interface FieldDef {
+  column: string;
+  label: string;
+  type: FieldType;
+  options?: readonly string[];
+  help?: string;
+}
+
+export interface MetricDraft {
+  label: string;
+  value: string;
+  ratio: string;
+}
+
+export type FieldValue = string | number | boolean | string[] | object | null;
+export type FieldDefault = string | boolean | string[] | MetricDraft[];
+
+export function parseFields(fields: FieldDef[], formData: FormData): Record<string, FieldValue> {
+  const out: Record<string, FieldValue> = {};
+  for (const f of fields) {
+    const raw = formData.get(f.column);
+    const text = typeof raw === 'string' ? raw.trim() : '';
+    switch (f.type) {
+      case 'text':
+      case 'textarea':
+      case 'url':
+      case 'select':
+        out[f.column] = text === '' ? null : text;
+        break;
+      case 'bullets':
+        out[f.column] = formData
+          .getAll(f.column)
+          .map((entry) => String(entry).trim())
+          .filter(Boolean);
+        break;
+      case 'tags':
+        out[f.column] = text
+          .split(',')
+          .map((tag) => tag.trim())
+          .filter(Boolean);
+        break;
+      case 'number':
+        out[f.column] = text === '' ? null : Number(text);
+        break;
+      case 'sort_order':
+        out[f.column] = text === '' ? 0 : Number(text);
+        break;
+      case 'checkbox':
+        out[f.column] = raw !== null;
+        break;
+      case 'metrics': {
+        const labels = formData.getAll(`${f.column}.label`).map((v) => String(v).trim());
+        const values = formData.getAll(`${f.column}.value`).map((v) => String(v).trim());
+        const ratios = formData.getAll(`${f.column}.ratio`).map((v) => String(v).trim());
+        const metrics = labels
+          .map((label, i) => ({ label, value: values[i] ?? '', ratio: ratios[i] ?? '' }))
+          .filter((m) => m.label || m.value || m.ratio)
+          .map((m) => ({
+            label: m.label,
+            value: m.value,
+            ...(m.ratio !== '' ? { ratio: Number(m.ratio) } : {}),
+          }));
+        out[f.column] = metrics.length ? metrics : null;
+        break;
+      }
+      case 'runs':
+        out[f.column] = parseRuns(text);
+        break;
+    }
+  }
+  return out;
+}
+
+// builds form defaults for a row or a blank create form
+export function formDefaults(
+  fields: FieldDef[],
+  row?: Record<string, unknown>,
+): Record<string, FieldDefault> {
+  const out: Record<string, FieldDefault> = {};
+  for (const f of fields) out[f.column] = fieldDefault(f, row?.[f.column]);
+  return out;
+}
+
+// maps a row value to its form input value
+export function fieldDefault(f: FieldDef, value: unknown): FieldDefault {
+  switch (f.type) {
+    case 'checkbox':
+      return value === true;
+    case 'bullets':
+      return Array.isArray(value) ? (value as string[]) : [];
+    case 'tags':
+      return Array.isArray(value) ? (value as string[]).join(', ') : '';
+    case 'metrics':
+      return Array.isArray(value)
+        ? (value as ProjectMetric[]).map((m) => ({
+            label: m.label,
+            value: m.value,
+            ratio: m.ratio !== undefined ? String(m.ratio) : '',
+          }))
+        : [];
+    case 'runs':
+      return Array.isArray(value) ? serialiseRuns(value as AboutParagraph) : '';
+    case 'number':
+    case 'sort_order':
+      return typeof value === 'number' ? String(value) : '';
+    default:
+      return typeof value === 'string' ? value : '';
+  }
+}

--- a/jamesduxbury/src/admin/runs.ts
+++ b/jamesduxbury/src/admin/runs.ts
@@ -1,0 +1,25 @@
+import type { AboutParagraph, AboutRun } from '@/data/about';
+
+// splits markup into plain, strong, and em runs
+const MARKUP = /(\*\*[^*]+\*\*|\*[^*]+\*)/g;
+
+export function parseRuns(text: string): AboutParagraph {
+  return text
+    .split(MARKUP)
+    .filter((part) => part !== '')
+    .map((part): AboutRun => {
+      if (part.startsWith('**') && part.endsWith('**')) return { strong: part.slice(2, -2) };
+      if (part.startsWith('*') && part.endsWith('*')) return { em: part.slice(1, -1) };
+      return part;
+    });
+}
+
+export function serialiseRuns(runs: AboutParagraph): string {
+  return runs
+    .map((run) => {
+      if (typeof run === 'string') return run;
+      if ('strong' in run) return `**${run.strong}**`;
+      return `*${run.em}*`;
+    })
+    .join('');
+}

--- a/jamesduxbury/src/admin/sections.ts
+++ b/jamesduxbury/src/admin/sections.ts
@@ -1,0 +1,208 @@
+import { z } from 'zod';
+import type { FieldDef } from './fields';
+
+export interface SectionConfig {
+  slug: string;
+  table: string;
+  title: string;
+  fields: FieldDef[];
+  schema: z.ZodType<Record<string, unknown>>;
+  listLabel: (row: Record<string, unknown>) => string;
+}
+
+const sortOrder = z.number().int().min(0);
+const year = z.number().int().min(1900).max(2100);
+const optionalUrl = z.url().nullable();
+// stores NULL rather than an empty array for nullable text array columns
+const optionalBullets = z
+  .array(z.string().min(1))
+  .transform((lines) => (lines.length ? lines : null));
+
+const metricSchema = z.object({
+  label: z.string().min(1),
+  value: z.string().min(1),
+  ratio: z.number().min(0).max(1).optional(),
+});
+
+const runSchema = z.union([
+  z.string().min(1),
+  z.object({ strong: z.string().min(1) }),
+  z.object({ em: z.string().min(1) }),
+]);
+
+export const SECTIONS: SectionConfig[] = [
+  {
+    slug: 'projects',
+    table: 'projects',
+    title: 'Projects',
+    fields: [
+      { column: 'title', label: 'Title', type: 'text' },
+      { column: 'slug', label: 'Slug', type: 'text', help: 'lowercase letters, digits, hyphens' },
+      { column: 'subtitle', label: 'Subtitle', type: 'text' },
+      {
+        column: 'status',
+        label: 'Status',
+        type: 'select',
+        options: ['live', 'dev', 'exam', 'shipped'],
+      },
+      { column: 'under_exam', label: 'Under exam', type: 'checkbox' },
+      { column: 'year_start', label: 'Year start', type: 'number' },
+      { column: 'year_end', label: 'Year end', type: 'number' },
+      { column: 'tech_stack', label: 'Tech stack', type: 'tags', help: 'comma-separated' },
+      { column: 'highlights', label: 'Highlights', type: 'bullets' },
+      {
+        column: 'metrics',
+        label: 'Metrics',
+        type: 'metrics',
+        help: 'ratio is the 0–1 bar fill, optional — remove all rows for none',
+      },
+      { column: 'image_path', label: 'Image path', type: 'text' },
+      { column: 'github_link', label: 'GitHub link', type: 'url' },
+      { column: 'live_link', label: 'Live link', type: 'url' },
+      { column: 'sort_order', label: 'Sort order', type: 'sort_order' },
+    ],
+    schema: z.object({
+      title: z.string().min(1),
+      slug: z.string().regex(/^[a-z0-9-]+$/, 'lowercase letters, digits, and hyphens only'),
+      subtitle: z.string().min(1),
+      status: z.enum(['live', 'dev', 'exam', 'shipped']),
+      under_exam: z.boolean(),
+      year_start: year,
+      year_end: year,
+      tech_stack: z.array(z.string().min(1)).min(1),
+      highlights: z.array(z.string().min(1)).min(1),
+      metrics: z.array(metricSchema).min(1).nullable(),
+      image_path: z.string().min(1).nullable(),
+      github_link: optionalUrl,
+      live_link: optionalUrl,
+      sort_order: sortOrder,
+    }),
+    listLabel: (row) => String(row.title),
+  },
+  {
+    slug: 'experience',
+    table: 'experience',
+    title: 'Experience',
+    fields: [
+      { column: 'title', label: 'Title', type: 'text' },
+      { column: 'organisation', label: 'Organisation', type: 'text' },
+      { column: 'meta', label: 'Meta', type: 'text', help: 'optional, e.g. team or location' },
+      {
+        column: 'period',
+        label: 'Period',
+        type: 'text',
+        help: 'display text, e.g. Jun – Sep 2025',
+      },
+      { column: 'year_start', label: 'Year start', type: 'number' },
+      { column: 'year_end', label: 'Year end', type: 'number', help: 'leave empty for present' },
+      { column: 'bullets', label: 'Bullets', type: 'bullets' },
+      { column: 'sort_order', label: 'Sort order', type: 'sort_order' },
+    ],
+    schema: z.object({
+      title: z.string().min(1),
+      organisation: z.string().min(1),
+      meta: z.string().min(1).nullable(),
+      period: z.string().min(1),
+      year_start: year,
+      year_end: year.nullable(),
+      bullets: optionalBullets,
+      sort_order: sortOrder,
+    }),
+    listLabel: (row) => `${String(row.title)} · ${String(row.organisation)}`,
+  },
+  {
+    slug: 'education',
+    table: 'education',
+    title: 'Education',
+    fields: [
+      { column: 'qualification', label: 'Qualification', type: 'text' },
+      { column: 'institution', label: 'Institution', type: 'text' },
+      { column: 'period', label: 'Period', type: 'text' },
+      { column: 'year_end', label: 'Year end', type: 'number' },
+      { column: 'bullets', label: 'Bullets', type: 'bullets' },
+      { column: 'sort_order', label: 'Sort order', type: 'sort_order' },
+    ],
+    schema: z.object({
+      qualification: z.string().min(1),
+      institution: z.string().min(1),
+      period: z.string().min(1),
+      year_end: year,
+      bullets: optionalBullets,
+      sort_order: sortOrder,
+    }),
+    listLabel: (row) => String(row.qualification),
+  },
+  {
+    slug: 'certifications',
+    table: 'certifications',
+    title: 'Certifications',
+    fields: [
+      { column: 'name', label: 'Name', type: 'text' },
+      { column: 'year', label: 'Year', type: 'text', help: 'display text, e.g. 2024' },
+      { column: 'img_path', label: 'Image path', type: 'text' },
+      { column: 'certification_link', label: 'Certification link', type: 'url' },
+      { column: 'sort_order', label: 'Sort order', type: 'sort_order' },
+    ],
+    schema: z.object({
+      name: z.string().min(1),
+      year: z.string().min(1),
+      img_path: z.string().min(1).nullable(),
+      certification_link: optionalUrl,
+      sort_order: sortOrder,
+    }),
+    listLabel: (row) => String(row.name),
+  },
+  {
+    slug: 'skills',
+    table: 'skill_groups',
+    title: 'Skills',
+    fields: [
+      { column: 'heading', label: 'Heading', type: 'text' },
+      { column: 'skills', label: 'Skills', type: 'tags', help: 'comma-separated' },
+      { column: 'sort_order', label: 'Sort order', type: 'sort_order' },
+    ],
+    schema: z.object({
+      heading: z.string().min(1),
+      skills: z.array(z.string().min(1)).min(1),
+      sort_order: sortOrder,
+    }),
+    listLabel: (row) => String(row.heading),
+  },
+  {
+    slug: 'about',
+    table: 'about_paragraphs',
+    title: 'About',
+    fields: [
+      {
+        column: 'runs',
+        label: 'Paragraph',
+        type: 'runs',
+        help: 'use **bold** and *italic* markup',
+      },
+      { column: 'sort_order', label: 'Sort order', type: 'sort_order' },
+    ],
+    schema: z.object({
+      runs: z.array(runSchema).min(1),
+      sort_order: sortOrder,
+    }),
+    listLabel: (row) => {
+      const runs = row.runs;
+      const text = Array.isArray(runs)
+        ? runs
+            .map((run: unknown) => {
+              if (typeof run === 'string') return run;
+              const obj = run as { strong?: string; em?: string };
+              return obj.strong ?? obj.em ?? '';
+            })
+            .join('')
+        : '';
+      return text.length > 80 ? `${text.slice(0, 80)}…` : text;
+    },
+  },
+];
+
+export function getSection(slug: string): SectionConfig {
+  const section = SECTIONS.find((s) => s.slug === slug);
+  if (!section) throw new Error(`Unknown admin section: ${slug}`);
+  return section;
+}

--- a/jamesduxbury/src/admin/sql.ts
+++ b/jamesduxbury/src/admin/sql.ts
@@ -1,0 +1,72 @@
+import { getSql } from '@/db';
+
+export interface AdminRow extends Record<string, unknown> {
+  id: number;
+}
+
+// table and column names come from the static section registry, not user input
+
+export async function listRows(table: string): Promise<AdminRow[]> {
+  return (await getSql().query(`SELECT * FROM ${table} ORDER BY sort_order, id`)) as AdminRow[];
+}
+
+export async function getRow(table: string, id: number): Promise<AdminRow | null> {
+  const rows = (await getSql().query(`SELECT * FROM ${table} WHERE id = $1`, [id])) as AdminRow[];
+  return rows[0] ?? null;
+}
+
+export async function countRows(table: string): Promise<number> {
+  const rows = (await getSql().query(`SELECT count(*)::int AS count FROM ${table}`)) as {
+    count: number;
+  }[];
+  return rows[0].count;
+}
+
+export async function insertRow(table: string, values: Record<string, unknown>): Promise<void> {
+  const cols = Object.keys(values);
+  const params = cols.map((_, i) => `$${i + 1}`);
+  await getSql().query(
+    `INSERT INTO ${table} (${cols.join(', ')}) VALUES (${params.join(', ')})`,
+    cols.map((c) => values[c]),
+  );
+}
+
+export async function updateRow(
+  table: string,
+  id: number,
+  values: Record<string, unknown>,
+): Promise<void> {
+  const cols = Object.keys(values);
+  const sets = cols.map((c, i) => `${c} = $${i + 1}`);
+  await getSql().query(
+    `UPDATE ${table} SET ${sets.join(', ')}, updated_at = now() WHERE id = $${cols.length + 1}`,
+    [...cols.map((c) => values[c]), id],
+  );
+}
+
+export async function deleteRow(table: string, id: number): Promise<void> {
+  await getSql().query(`DELETE FROM ${table} WHERE id = $1`, [id]);
+}
+
+// shifts rows at or below sortOrder down one place
+export async function makeRoomAt(
+  table: string,
+  sortOrder: number,
+  excludeId: number | null,
+): Promise<void> {
+  const sql = getSql();
+  const clash = (await sql.query(
+    `SELECT 1 FROM ${table} WHERE sort_order = $1 AND ($2::int IS NULL OR id <> $2) LIMIT 1`,
+    [sortOrder, excludeId],
+  )) as unknown[];
+  if (clash.length === 0) return;
+  const rows = (await sql.query(
+    `SELECT id FROM ${table} WHERE sort_order >= $1 AND ($2::int IS NULL OR id <> $2)
+     ORDER BY sort_order DESC, id DESC`,
+    [sortOrder, excludeId],
+  )) as { id: number }[];
+  // updates highest sort_order first to avoid unique collisions
+  for (const row of rows) {
+    await sql.query(`UPDATE ${table} SET sort_order = sort_order + 1 WHERE id = $1`, [row.id]);
+  }
+}

--- a/jamesduxbury/src/app/admin/[section]/[id]/page.tsx
+++ b/jamesduxbury/src/app/admin/[section]/[id]/page.tsx
@@ -1,0 +1,32 @@
+import { notFound } from 'next/navigation';
+import { saveItem } from '@/admin/actions';
+import { formDefaults } from '@/admin/fields';
+import { SECTIONS } from '@/admin/sections';
+import { getRow } from '@/admin/sql';
+import { AdminPanel } from '@/components/admin/AdminPanel';
+import { SectionForm } from '@/components/admin/SectionForm';
+
+export default async function SectionEditPage({
+  params,
+}: {
+  params: Promise<{ section: string; id: string }>;
+}) {
+  const { section: slug, id: idParam } = await params;
+  const section = SECTIONS.find((s) => s.slug === slug);
+  if (!section || !/^\d+$/.test(idParam)) notFound();
+
+  const id = Number(idParam);
+  const row = await getRow(section.table, id);
+  if (!row) notFound();
+
+  return (
+    <AdminPanel title={`${section.title.toLowerCase()} · edit`} meta={section.listLabel(row)}>
+      <SectionForm
+        fields={section.fields}
+        defaults={formDefaults(section.fields, row)}
+        action={saveItem.bind(null, section.slug, id)}
+        submitLabel="save →"
+      />
+    </AdminPanel>
+  );
+}

--- a/jamesduxbury/src/app/admin/[section]/new/page.tsx
+++ b/jamesduxbury/src/app/admin/[section]/new/page.tsx
@@ -1,0 +1,23 @@
+import { notFound } from 'next/navigation';
+import { saveItem } from '@/admin/actions';
+import { formDefaults } from '@/admin/fields';
+import { SECTIONS } from '@/admin/sections';
+import { AdminPanel } from '@/components/admin/AdminPanel';
+import { SectionForm } from '@/components/admin/SectionForm';
+
+export default async function SectionNewPage({ params }: { params: Promise<{ section: string }> }) {
+  const { section: slug } = await params;
+  const section = SECTIONS.find((s) => s.slug === slug);
+  if (!section) notFound();
+
+  return (
+    <AdminPanel title={`${section.title.toLowerCase()} · new`}>
+      <SectionForm
+        fields={section.fields}
+        defaults={formDefaults(section.fields)}
+        action={saveItem.bind(null, section.slug, null)}
+        submitLabel="create →"
+      />
+    </AdminPanel>
+  );
+}

--- a/jamesduxbury/src/app/admin/[section]/page.tsx
+++ b/jamesduxbury/src/app/admin/[section]/page.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { deleteItem } from '@/admin/actions';
+import { SECTIONS } from '@/admin/sections';
+import { listRows } from '@/admin/sql';
+import { AdminPanel } from '@/components/admin/AdminPanel';
+import { DeleteButton } from '@/components/admin/DeleteButton';
+
+export default async function SectionListPage({
+  params,
+}: {
+  params: Promise<{ section: string }>;
+}) {
+  const { section: slug } = await params;
+  const section = SECTIONS.find((s) => s.slug === slug);
+  if (!section) notFound();
+
+  const rows = await listRows(section.table);
+
+  return (
+    <AdminPanel title={section.title.toLowerCase()} meta={`${rows.length} rows`}>
+      <div className="divide-y divide-border">
+        {rows.map((row) => (
+          <div key={row.id} className="flex items-center gap-4 px-4 py-4 sm:px-6">
+            <span className="font-mono text-xs text-muted/70">#{String(row.sort_order)}</span>
+            <Link
+              href={`/admin/${section.slug}/${row.id}`}
+              className="min-w-0 flex-1 truncate font-mono text-sm text-text transition-colors hover:text-accent"
+            >
+              {section.listLabel(row)}
+            </Link>
+            <DeleteButton action={deleteItem.bind(null, section.slug, row.id)} />
+          </div>
+        ))}
+        {rows.length === 0 && (
+          <p className="px-4 py-5 font-mono text-xs uppercase tracking-[0.18em] text-muted sm:px-6">
+            {`>`} no rows
+          </p>
+        )}
+        <div className="px-4 py-4 sm:px-6">
+          <Link
+            href={`/admin/${section.slug}/new`}
+            className="font-mono text-xs uppercase tracking-[0.18em] text-accent transition-colors hover:text-text"
+          >
+            + new {section.title.toLowerCase().replace(/s$/, '')}
+          </Link>
+        </div>
+      </div>
+    </AdminPanel>
+  );
+}

--- a/jamesduxbury/src/app/admin/analytics/page.tsx
+++ b/jamesduxbury/src/app/admin/analytics/page.tsx
@@ -1,0 +1,149 @@
+import {
+  getAvgDurations,
+  getRecentSessions,
+  getTopCountries,
+  getTopPaths,
+  getTopReferrers,
+  getViewsPerDay,
+  getVisitTotals,
+} from '@/db/analytics';
+import { AdminPanel } from '@/components/admin/AdminPanel';
+
+function formatDuration(ms: number): string {
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+}
+
+function CountList({ rows }: { rows: { label: string; views: number }[] }) {
+  const max = Math.max(...rows.map((row) => row.views), 1);
+  return (
+    <div className="divide-y divide-border">
+      {rows.map((row) => (
+        <div key={row.label} className="relative px-4 py-3 sm:px-6">
+          <div
+            className="absolute inset-y-0 left-0 bg-accent/10"
+            style={{ width: `${(row.views / max) * 100}%` }}
+          />
+          <div className="relative flex items-baseline justify-between gap-4">
+            <span className="truncate font-mono text-sm text-text">{row.label}</span>
+            <span className="font-mono text-xs text-muted">{row.views}</span>
+          </div>
+        </div>
+      ))}
+      {rows.length === 0 && (
+        <p className="px-4 py-4 font-mono text-xs uppercase tracking-[0.18em] text-muted sm:px-6">
+          {`>`} no data yet
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default async function AnalyticsPage() {
+  const [totals, perDay, topPaths, referrers, countries, durations, sessions] = await Promise.all([
+    getVisitTotals(),
+    getViewsPerDay(30),
+    getTopPaths(30),
+    getTopReferrers(30),
+    getTopCountries(30),
+    getAvgDurations(30),
+    getRecentSessions(12),
+  ]);
+
+  const maxDay = Math.max(...perDay.map((d) => d.views), 1);
+  const totalCards = [
+    { label: 'all-time', value: totals.allTime },
+    { label: 'last 30 days', value: totals.last30Days },
+    { label: 'last 7 days', value: totals.last7Days },
+  ];
+
+  return (
+    <>
+      <AdminPanel title="page views">
+        <div className="grid divide-y divide-border sm:grid-cols-3 sm:divide-x sm:divide-y-0">
+          {totalCards.map((card) => (
+            <div key={card.label} className="px-4 py-5 sm:px-6">
+              <p className="font-mono text-2xl text-text">{card.value}</p>
+              <p className="mt-1 font-mono text-[0.65rem] uppercase tracking-[0.2em] text-muted">
+                {card.label}
+              </p>
+            </div>
+          ))}
+        </div>
+      </AdminPanel>
+
+      <AdminPanel title="views per day" meta="last 30 days">
+        <div className="flex h-32 items-end gap-px px-4 py-4 sm:px-6">
+          {perDay.map((day) => (
+            <div
+              key={day.day}
+              title={`${day.day} · ${day.views} views`}
+              className="flex-1 bg-accent/60 transition-colors hover:bg-accent"
+              style={{ height: `${Math.max((day.views / maxDay) * 100, day.views > 0 ? 4 : 1)}%` }}
+            />
+          ))}
+        </div>
+      </AdminPanel>
+
+      <div className="grid gap-x-6 lg:grid-cols-2">
+        <AdminPanel title="top pages" meta="last 30 days">
+          <CountList rows={topPaths.map((r) => ({ label: r.path, views: r.views }))} />
+        </AdminPanel>
+        <AdminPanel title="top referrers" meta="last 30 days">
+          <CountList rows={referrers.map((r) => ({ label: r.source, views: r.views }))} />
+        </AdminPanel>
+        <AdminPanel title="top countries" meta="last 30 days">
+          <CountList rows={countries.map((r) => ({ label: r.country, views: r.views }))} />
+        </AdminPanel>
+        <AdminPanel title="avg time on page" meta="last 30 days">
+          <div className="divide-y divide-border">
+            {durations.map((row) => (
+              <div
+                key={row.path}
+                className="flex items-baseline justify-between gap-4 px-4 py-3 sm:px-6"
+              >
+                <span className="truncate font-mono text-sm text-text">{row.path}</span>
+                <span className="whitespace-nowrap font-mono text-xs text-muted">
+                  {formatDuration(row.avgMs)} · {row.samples}{' '}
+                  {row.samples === 1 ? 'sample' : 'samples'}
+                </span>
+              </div>
+            ))}
+            {durations.length === 0 && (
+              <p className="px-4 py-4 font-mono text-xs uppercase tracking-[0.18em] text-muted sm:px-6">
+                {`>`} no data yet
+              </p>
+            )}
+          </div>
+        </AdminPanel>
+      </div>
+
+      <AdminPanel title="recent sessions">
+        <div className="divide-y divide-border">
+          {sessions.map((session) => (
+            <div key={session.sessionId} className="px-4 py-4 sm:px-6">
+              <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
+                <span className="font-mono text-xs text-muted">{session.startedAt}</span>
+                {session.country && (
+                  <span className="font-mono text-xs text-muted">{session.country}</span>
+                )}
+                {session.totalMs !== null && (
+                  <span className="font-mono text-xs text-muted">
+                    {formatDuration(session.totalMs)}
+                  </span>
+                )}
+              </div>
+              <p className="mt-2 font-mono text-sm text-text/90">{session.paths.join(' → ')}</p>
+            </div>
+          ))}
+          {sessions.length === 0 && (
+            <p className="px-4 py-4 font-mono text-xs uppercase tracking-[0.18em] text-muted sm:px-6">
+              {`>`} no sessions yet
+            </p>
+          )}
+        </div>
+      </AdminPanel>
+    </>
+  );
+}

--- a/jamesduxbury/src/app/admin/layout.tsx
+++ b/jamesduxbury/src/app/admin/layout.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { auth, isAdminSession } from '@/auth';
+import { SECTIONS } from '@/admin/sections';
+
+// admin pages always render fresh
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Admin · James Duxbury',
+  robots: { index: false },
+};
+
+const navLink =
+  'font-mono text-xs uppercase tracking-[0.2em] text-muted transition-colors hover:text-accent';
+
+export default async function AdminLayout({ children }: { children: React.ReactNode }) {
+  const session = await auth();
+  if (!isAdminSession(session)) redirect('/signin');
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 pb-10 pt-28 sm:px-6 sm:pt-32">
+      <nav className="mb-8 flex flex-wrap gap-x-5 gap-y-2">
+        <Link href="/admin" className={navLink}>
+          admin
+        </Link>
+        {SECTIONS.map((section) => (
+          <Link key={section.slug} href={`/admin/${section.slug}`} className={navLink}>
+            {section.title.toLowerCase()}
+          </Link>
+        ))}
+        <Link href="/admin/messages" className={navLink}>
+          messages
+        </Link>
+        <Link href="/admin/analytics" className={navLink}>
+          analytics
+        </Link>
+        <Link href="/signout" className={`${navLink} ml-auto`}>
+          sign out
+        </Link>
+      </nav>
+      {children}
+    </div>
+  );
+}

--- a/jamesduxbury/src/app/admin/messages/page.tsx
+++ b/jamesduxbury/src/app/admin/messages/page.tsx
@@ -1,0 +1,61 @@
+import { markMessageRead } from '@/admin/actions';
+import { getSql } from '@/db';
+import { AdminPanel } from '@/components/admin/AdminPanel';
+
+interface MessageRow {
+  id: number;
+  name: string;
+  email: string;
+  message: string;
+  read: boolean;
+  received_at: string;
+}
+
+export default async function MessagesPage() {
+  const rows = (await getSql()`
+    SELECT id, name, email, message, read,
+      to_char(created_at, 'YYYY-MM-DD HH24:MI') AS received_at
+    FROM messages ORDER BY created_at DESC
+  `) as MessageRow[];
+
+  const unread = rows.filter((row) => !row.read).length;
+
+  return (
+    <AdminPanel title="messages" meta={`${unread} unread · ${rows.length} total`}>
+      <div className="divide-y divide-border">
+        {rows.map((row) => (
+          <div key={row.id} className={`px-4 py-5 sm:px-6 ${row.read ? 'opacity-60' : ''}`}>
+            <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
+              <span className="font-mono text-sm text-text">{row.name}</span>
+              <a
+                href={`mailto:${row.email}`}
+                className="font-mono text-xs text-muted transition-colors hover:text-accent"
+              >
+                {row.email}
+              </a>
+              <span className="ml-auto font-mono text-[0.65rem] text-muted/70">
+                {row.received_at}
+              </span>
+            </div>
+            <p className="mt-3 whitespace-pre-wrap font-mono text-sm text-text/90">{row.message}</p>
+            {!row.read && (
+              <form action={markMessageRead.bind(null, row.id)} className="mt-3">
+                <button
+                  type="submit"
+                  className="font-mono text-xs uppercase tracking-[0.18em] text-accent transition-colors hover:text-text"
+                >
+                  mark as read
+                </button>
+              </form>
+            )}
+          </div>
+        ))}
+        {rows.length === 0 && (
+          <p className="px-4 py-5 font-mono text-xs uppercase tracking-[0.18em] text-muted sm:px-6">
+            {`>`} inbox empty
+          </p>
+        )}
+      </div>
+    </AdminPanel>
+  );
+}

--- a/jamesduxbury/src/app/admin/page.tsx
+++ b/jamesduxbury/src/app/admin/page.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link';
+import { SECTIONS } from '@/admin/sections';
+import { countRows } from '@/admin/sql';
+import { getMessageCounts, getVisitTotals } from '@/db/analytics';
+
+export default async function AdminPage() {
+  const [counts, messages, visits] = await Promise.all([
+    Promise.all(SECTIONS.map((section) => countRows(section.table))),
+    getMessageCounts(),
+    getVisitTotals(),
+  ]);
+
+  const cards = [
+    ...SECTIONS.map((section, i) => ({
+      href: `/admin/${section.slug}`,
+      title: section.title,
+      meta: `${counts[i]} ${counts[i] === 1 ? 'row' : 'rows'}`,
+    })),
+    {
+      href: '/admin/messages',
+      title: 'Messages',
+      meta: `${messages.unread} unread · ${messages.total} total`,
+    },
+    {
+      href: '/admin/analytics',
+      title: 'Analytics',
+      meta: `${visits.last7Days} views / 7d · ${visits.allTime} all-time`,
+    },
+  ];
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {cards.map((card) => (
+        <Link
+          key={card.href}
+          href={card.href}
+          className="group border border-border bg-surface/40 px-4 py-5 backdrop-blur-sm transition-colors hover:border-accent sm:px-6"
+        >
+          <p className="font-mono text-sm uppercase tracking-[0.18em] text-text transition-colors group-hover:text-accent">
+            {card.title}
+          </p>
+          <p className="mt-2 font-mono text-xs text-muted">{card.meta}</p>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/jamesduxbury/src/app/api/auth/[...nextauth]/route.ts
+++ b/jamesduxbury/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from '@/auth';
+
+export const { GET, POST } = handlers;

--- a/jamesduxbury/src/app/api/visit/route.ts
+++ b/jamesduxbury/src/app/api/visit/route.ts
@@ -1,4 +1,5 @@
 import { getSql } from '@/db';
+import { auth, isAdminSession } from '@/auth';
 
 const BOT_UA = /bot|crawl|spider|slurp|headless|preview|monitor|lighthouse/i;
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -14,6 +15,10 @@ interface VisitPayload {
 
 export async function POST(req: Request) {
   if (BOT_UA.test(req.headers.get('user-agent') ?? '')) {
+    return new Response(null, { status: 204 });
+  }
+  // skips the signed-in admin's visits
+  if (isAdminSession(await auth())) {
     return new Response(null, { status: 204 });
   }
 

--- a/jamesduxbury/src/app/signin/page.tsx
+++ b/jamesduxbury/src/app/signin/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { auth, signIn } from '@/auth';
+import { auth, isAdminSession, signIn } from '@/auth';
+import { AutoSubmit } from '@/components/AutoSubmit';
 
 export const metadata: Metadata = {
   title: 'Sign in · James Duxbury',
@@ -14,7 +15,7 @@ export default async function SignInPage({
   searchParams: Promise<{ callbackUrl?: string; error?: string }>;
 }) {
   const session = await auth();
-  if (session) redirect('/admin');
+  if (isAdminSession(session)) redirect('/admin');
   const { callbackUrl, error } = await searchParams;
 
   return (
@@ -42,11 +43,13 @@ export default async function SignInPage({
             </p>
           )}
           <form
+            id="signin-form"
             action={async () => {
               'use server';
               await signIn('github', { redirectTo: callbackUrl ?? '/admin' });
             }}
           >
+            {!error && <AutoSubmit formId="signin-form" />}
             <button
               type="submit"
               className="w-full rounded-full border border-accent bg-accent/10 px-5 py-2 font-mono text-sm uppercase tracking-[0.18em] text-accent transition-colors hover:bg-accent hover:text-text"

--- a/jamesduxbury/src/app/signin/page.tsx
+++ b/jamesduxbury/src/app/signin/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { auth, signIn } from '@/auth';
+
+export const metadata: Metadata = {
+  title: 'Sign in · James Duxbury',
+  robots: { index: false },
+};
+
+export default async function SignInPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ callbackUrl?: string; error?: string }>;
+}) {
+  const session = await auth();
+  if (session) redirect('/admin');
+  const { callbackUrl, error } = await searchParams;
+
+  return (
+    <main className="mx-auto max-w-md px-4 pb-10 pt-28 sm:px-6 sm:pt-32">
+      <Link
+        href="/"
+        className="mb-8 inline-block font-mono text-xs uppercase tracking-[0.2em] text-muted transition-colors hover:text-accent"
+      >
+        ← / home
+      </Link>
+
+      <div className="border border-border bg-surface/40 backdrop-blur-sm">
+        <div className="border-b border-border px-4 py-5 sm:px-6">
+          <p className="font-mono text-xs uppercase tracking-[0.18em] text-muted">
+            {`>`} restricted channel · operator access only
+          </p>
+        </div>
+        <div className="flex flex-col gap-4 px-4 py-5 sm:px-6">
+          {error && (
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-danger">
+              {`>`}{' '}
+              {error === 'AccessDenied'
+                ? 'access denied · account not authorised'
+                : 'sign-in failed · try again'}
+            </p>
+          )}
+          <form
+            action={async () => {
+              'use server';
+              await signIn('github', { redirectTo: callbackUrl ?? '/admin' });
+            }}
+          >
+            <button
+              type="submit"
+              className="w-full rounded-full border border-accent bg-accent/10 px-5 py-2 font-mono text-sm uppercase tracking-[0.18em] text-accent transition-colors hover:bg-accent hover:text-text"
+            >
+              sign in with github →
+            </button>
+          </form>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/jamesduxbury/src/app/signout/page.tsx
+++ b/jamesduxbury/src/app/signout/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { auth, signOut } from '@/auth';
+
+export const metadata: Metadata = {
+  title: 'Sign out · James Duxbury',
+  robots: { index: false },
+};
+
+export default async function SignOutPage() {
+  const session = await auth();
+  if (!session) redirect('/');
+
+  return (
+    <main className="mx-auto max-w-md px-4 pb-10 pt-28 sm:px-6 sm:pt-32">
+      <Link
+        href="/admin"
+        className="mb-8 inline-block font-mono text-xs uppercase tracking-[0.2em] text-muted transition-colors hover:text-accent"
+      >
+        ← / admin
+      </Link>
+
+      <div className="border border-border bg-surface/40 backdrop-blur-sm">
+        <div className="border-b border-border px-4 py-5 sm:px-6">
+          <p className="font-mono text-xs uppercase tracking-[0.18em] text-muted">
+            {`>`} end session · {session.user?.name ?? 'operator'}
+          </p>
+        </div>
+        <div className="px-4 py-5 sm:px-6">
+          <form
+            action={async () => {
+              'use server';
+              await signOut({ redirectTo: '/' });
+            }}
+          >
+            <button
+              type="submit"
+              className="w-full rounded-full border border-danger bg-danger/10 px-5 py-2 font-mono text-sm uppercase tracking-[0.18em] text-danger transition-colors hover:bg-danger hover:text-text"
+            >
+              sign out →
+            </button>
+          </form>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/jamesduxbury/src/auth.ts
+++ b/jamesduxbury/src/auth.ts
@@ -1,0 +1,47 @@
+import NextAuth, { type Profile, type Session } from 'next-auth';
+import type { JWT } from 'next-auth/jwt';
+import GitHub from 'next-auth/providers/github';
+
+declare module 'next-auth' {
+  interface User {
+    login?: string;
+  }
+}
+
+// github account allowed to sign in
+export const ALLOWED_LOGIN = 'jsduxie';
+
+export function isAllowedLogin(login: unknown): boolean {
+  return login === ALLOWED_LOGIN;
+}
+
+export function isAdminSession(session: Session | null): boolean {
+  return isAllowedLogin(session?.user?.login);
+}
+
+export const authCallbacks = {
+  signIn({ profile }: { profile?: Profile }) {
+    return isAllowedLogin(profile?.login);
+  },
+  jwt({ token, profile }: { token: JWT; profile?: Profile }) {
+    if (typeof profile?.login === 'string') token.login = profile.login;
+    return token;
+  },
+  session({ session, token }: { session: Session; token: JWT }) {
+    if (session.user)
+      session.user.login = typeof token.login === 'string' ? token.login : undefined;
+    return session;
+  },
+};
+
+export const { handlers, auth, signIn, signOut } = NextAuth({
+  providers: [
+    GitHub({
+      clientId: process.env.GITHUB_ID,
+      clientSecret: process.env.GITHUB_SECRET,
+    }),
+  ],
+  session: { strategy: 'jwt' },
+  pages: { signIn: '/signin', error: '/signin' },
+  callbacks: authCallbacks,
+});

--- a/jamesduxbury/src/components/AutoSubmit.tsx
+++ b/jamesduxbury/src/components/AutoSubmit.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { useEffect } from 'react';
+
+// submits the named form on mount
+export function AutoSubmit({ formId }: { formId: string }) {
+  useEffect(() => {
+    const form = document.getElementById(formId);
+    if (form instanceof HTMLFormElement) form.requestSubmit();
+  }, [formId]);
+  return null;
+}

--- a/jamesduxbury/src/components/admin/AdminPanel.tsx
+++ b/jamesduxbury/src/components/admin/AdminPanel.tsx
@@ -1,0 +1,19 @@
+interface AdminPanelProps {
+  title: string;
+  meta?: string;
+  children: React.ReactNode;
+}
+
+export function AdminPanel({ title, meta, children }: AdminPanelProps) {
+  return (
+    <section className="mb-8">
+      <div className="mb-3 flex items-baseline justify-between">
+        <h2 className="font-mono text-xs uppercase tracking-[0.2em] text-muted">
+          {`>`} {title}
+        </h2>
+        {meta && <span className="font-mono text-[0.65rem] text-muted/70">{meta}</span>}
+      </div>
+      <div className="border border-border bg-surface/40 backdrop-blur-sm">{children}</div>
+    </section>
+  );
+}

--- a/jamesduxbury/src/components/admin/DeleteButton.tsx
+++ b/jamesduxbury/src/components/admin/DeleteButton.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+interface DeleteButtonProps {
+  action: () => Promise<void>;
+}
+
+export function DeleteButton({ action }: DeleteButtonProps) {
+  return (
+    <form
+      action={action}
+      onSubmit={(e) => {
+        if (!confirm('Delete this item? This cannot be undone.')) e.preventDefault();
+      }}
+    >
+      <button
+        type="submit"
+        className="font-mono text-xs uppercase tracking-[0.18em] text-danger/70 transition-colors hover:text-danger"
+      >
+        delete
+      </button>
+    </form>
+  );
+}

--- a/jamesduxbury/src/components/admin/SectionForm.tsx
+++ b/jamesduxbury/src/components/admin/SectionForm.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+import { useActionState, useState } from 'react';
+import type { FormState } from '@/admin/actions';
+import type { FieldDef, FieldDefault, MetricDraft } from '@/admin/fields';
+
+const INITIAL_STATE: FormState = { message: null, fieldErrors: {} };
+
+const fieldLabel = 'font-mono text-[0.65rem] uppercase tracking-[0.2em] text-muted sm:text-xs';
+const fieldInput =
+  'mt-2 w-full border border-border bg-bg px-3 py-2.5 font-mono text-sm text-text placeholder:text-muted/60 transition-colors focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent';
+const rowButton =
+  'font-mono text-xs uppercase tracking-[0.18em] text-muted transition-colors hover:text-danger';
+const addButton =
+  'mt-3 font-mono text-xs uppercase tracking-[0.18em] text-accent transition-colors hover:text-text';
+
+interface SectionFormProps {
+  fields: FieldDef[];
+  defaults: Record<string, FieldDefault>;
+  action: (prev: FormState, formData: FormData) => Promise<FormState>;
+  submitLabel: string;
+}
+
+function BulletsField({ column, initial }: { column: string; initial: string[] }) {
+  const [bullets, setBullets] = useState<string[]>(initial.length ? initial : ['']);
+
+  return (
+    <div>
+      {bullets.map((bullet, i) => (
+        <div key={i} className="mt-2 flex items-center gap-3">
+          <input
+            name={column}
+            type="text"
+            value={bullet}
+            onChange={(e) => setBullets(bullets.map((b, j) => (j === i ? e.target.value : b)))}
+            className={`${fieldInput} mt-0`}
+          />
+          <button
+            type="button"
+            onClick={() => setBullets(bullets.filter((_, j) => j !== i))}
+            className={rowButton}
+          >
+            remove
+          </button>
+        </div>
+      ))}
+      <button type="button" onClick={() => setBullets([...bullets, ''])} className={addButton}>
+        + add bullet
+      </button>
+    </div>
+  );
+}
+
+const EMPTY_METRIC: MetricDraft = { label: '', value: '', ratio: '' };
+
+function MetricsField({ column, initial }: { column: string; initial: MetricDraft[] }) {
+  const [metrics, setMetrics] = useState<MetricDraft[]>(initial);
+
+  const update = (i: number, key: keyof MetricDraft, value: string) =>
+    setMetrics(metrics.map((m, j) => (j === i ? { ...m, [key]: value } : m)));
+
+  return (
+    <div>
+      {metrics.map((metric, i) => (
+        <div key={i} className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+          <input
+            name={`${column}.label`}
+            type="text"
+            placeholder="label"
+            value={metric.label}
+            onChange={(e) => update(i, 'label', e.target.value)}
+            className={`${fieldInput} mt-0 sm:flex-1`}
+          />
+          <input
+            name={`${column}.value`}
+            type="text"
+            placeholder="value"
+            value={metric.value}
+            onChange={(e) => update(i, 'value', e.target.value)}
+            className={`${fieldInput} mt-0 sm:w-32`}
+          />
+          <input
+            name={`${column}.ratio`}
+            type="number"
+            step="0.001"
+            min="0"
+            max="1"
+            placeholder="ratio"
+            value={metric.ratio}
+            onChange={(e) => update(i, 'ratio', e.target.value)}
+            className={`${fieldInput} mt-0 sm:w-28`}
+          />
+          <button
+            type="button"
+            onClick={() => setMetrics(metrics.filter((_, j) => j !== i))}
+            className={rowButton}
+          >
+            remove
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={() => setMetrics([...metrics, EMPTY_METRIC])}
+        className={addButton}
+      >
+        + add metric
+      </button>
+    </div>
+  );
+}
+
+function FieldInput({ field, defaultValue }: { field: FieldDef; defaultValue: FieldDefault }) {
+  const text = typeof defaultValue === 'string' ? defaultValue : '';
+  switch (field.type) {
+    case 'textarea':
+    case 'runs':
+      return (
+        <textarea
+          id={field.column}
+          name={field.column}
+          rows={field.type === 'runs' ? 4 : 5}
+          defaultValue={text}
+          className={`${fieldInput} resize-y`}
+        />
+      );
+    case 'bullets':
+      return (
+        <BulletsField
+          column={field.column}
+          initial={Array.isArray(defaultValue) ? (defaultValue as string[]) : []}
+        />
+      );
+    case 'metrics':
+      return (
+        <MetricsField
+          column={field.column}
+          initial={Array.isArray(defaultValue) ? (defaultValue as MetricDraft[]) : []}
+        />
+      );
+    case 'select':
+      return (
+        <div className="relative mt-2">
+          <select
+            id={field.column}
+            name={field.column}
+            defaultValue={text}
+            className={`${fieldInput} mt-0 cursor-pointer appearance-none pr-10`}
+          >
+            {field.options?.map((option) => (
+              <option key={option} value={option} className="bg-bg text-text">
+                {option}
+              </option>
+            ))}
+          </select>
+          <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 font-mono text-xs text-muted">
+            ▾
+          </span>
+        </div>
+      );
+    case 'checkbox':
+      return (
+        <label htmlFor={field.column} className="mt-2 flex w-fit cursor-pointer items-center gap-3">
+          <span className="relative flex h-4 w-4 items-center justify-center">
+            <input
+              id={field.column}
+              name={field.column}
+              type="checkbox"
+              defaultChecked={defaultValue === true}
+              className="peer h-4 w-4 cursor-pointer appearance-none border border-border bg-bg transition-colors checked:border-accent checked:bg-accent focus:outline-none focus:ring-1 focus:ring-accent"
+            />
+            <span className="pointer-events-none absolute hidden font-mono text-[0.65rem] leading-none text-bg peer-checked:block">
+              ✓
+            </span>
+          </span>
+          <span className="font-mono text-xs uppercase tracking-[0.18em] text-muted">enabled</span>
+        </label>
+      );
+    case 'number':
+    case 'sort_order':
+      return (
+        <input
+          id={field.column}
+          name={field.column}
+          type="number"
+          defaultValue={text}
+          className={fieldInput}
+        />
+      );
+    case 'url':
+      return (
+        <input
+          id={field.column}
+          name={field.column}
+          type="url"
+          defaultValue={text}
+          className={fieldInput}
+        />
+      );
+    default:
+      return (
+        <input
+          id={field.column}
+          name={field.column}
+          type="text"
+          defaultValue={text}
+          className={fieldInput}
+        />
+      );
+  }
+}
+
+export function SectionForm({ fields, defaults, action, submitLabel }: SectionFormProps) {
+  const [state, formAction, isPending] = useActionState(action, INITIAL_STATE);
+
+  return (
+    <form action={formAction} className="divide-y divide-border">
+      {fields.map((field) => (
+        <div key={field.column} className="relative px-4 py-5 sm:px-6">
+          <label htmlFor={field.column} className={fieldLabel}>
+            {field.label}
+          </label>
+          {field.help && (
+            <p className="mt-1 font-mono text-[0.65rem] text-muted/70">{field.help}</p>
+          )}
+          <FieldInput field={field} defaultValue={defaults[field.column] ?? ''} />
+          {state.fieldErrors[field.column] && (
+            <p className="mt-2 font-mono text-xs text-danger">
+              {`>`} {state.fieldErrors[field.column]}
+            </p>
+          )}
+        </div>
+      ))}
+
+      <div className="flex flex-col items-stretch gap-3 px-4 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+        <div className="font-mono text-xs uppercase tracking-[0.18em] text-muted">
+          {state.message && (
+            <span className="text-danger">
+              {`>`} {state.message}
+            </span>
+          )}
+          {isPending && <span>{`>`} saving…</span>}
+        </div>
+        <button
+          type="submit"
+          disabled={isPending}
+          className="rounded-full border border-accent bg-accent/10 px-5 py-2 font-mono text-sm uppercase tracking-[0.18em] text-accent transition-colors hover:bg-accent hover:text-text disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isPending ? 'saving…' : submitLabel}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/jamesduxbury/src/components/admin/SectionForm.tsx
+++ b/jamesduxbury/src/components/admin/SectionForm.tsx
@@ -29,6 +29,7 @@ function BulletsField({ column, initial }: { column: string; initial: string[] }
       {bullets.map((bullet, i) => (
         <div key={i} className="mt-2 flex items-center gap-3">
           <input
+            id={i === 0 ? column : undefined}
             name={column}
             type="text"
             value={bullet}
@@ -64,6 +65,7 @@ function MetricsField({ column, initial }: { column: string; initial: MetricDraf
       {metrics.map((metric, i) => (
         <div key={i} className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
           <input
+            id={i === 0 ? column : undefined}
             name={`${column}.label`}
             type="text"
             placeholder="label"

--- a/jamesduxbury/src/db/analytics.ts
+++ b/jamesduxbury/src/db/analytics.ts
@@ -1,0 +1,150 @@
+import { getSql } from '@/db';
+
+export interface VisitTotals {
+  allTime: number;
+  last7Days: number;
+  last30Days: number;
+}
+
+export interface DayCount {
+  day: string;
+  views: number;
+}
+
+export interface PathCount {
+  path: string;
+  views: number;
+}
+
+export interface SourceCount {
+  source: string;
+  views: number;
+}
+
+export interface CountryCount {
+  country: string;
+  views: number;
+}
+
+export interface PathDuration {
+  path: string;
+  avgMs: number;
+  samples: number;
+}
+
+export interface RecentSession {
+  sessionId: string;
+  startedAt: string;
+  country: string | null;
+  paths: string[];
+  totalMs: number | null;
+}
+
+interface TotalsRow {
+  all_time: number;
+  last_7: number;
+  last_30: number;
+}
+
+export async function getVisitTotals(): Promise<VisitTotals> {
+  const rows = (await getSql()`
+    SELECT
+      count(*)::int AS all_time,
+      count(*) FILTER (WHERE created_at > now() - interval '7 days')::int AS last_7,
+      count(*) FILTER (WHERE created_at > now() - interval '30 days')::int AS last_30
+    FROM page_views
+  `) as TotalsRow[];
+  const row = rows[0];
+  return { allTime: row.all_time, last7Days: row.last_7, last30Days: row.last_30 };
+}
+
+export async function getViewsPerDay(days: number): Promise<DayCount[]> {
+  const rows = (await getSql()`
+    SELECT to_char(d, 'YYYY-MM-DD') AS day, count(pv.id)::int AS views
+    FROM generate_series(now()::date - (${days}::int - 1), now()::date, interval '1 day') AS d
+    LEFT JOIN page_views pv ON pv.created_at::date = d::date
+    GROUP BY d ORDER BY d
+  `) as DayCount[];
+  return rows;
+}
+
+export async function getTopPaths(days: number): Promise<PathCount[]> {
+  const rows = (await getSql()`
+    SELECT path, count(*)::int AS views
+    FROM page_views
+    WHERE created_at > now() - make_interval(days => ${days})
+    GROUP BY path ORDER BY views DESC, path LIMIT 10
+  `) as PathCount[];
+  return rows;
+}
+
+export async function getTopReferrers(days: number): Promise<SourceCount[]> {
+  // groups referrers by host
+  const rows = (await getSql()`
+    SELECT coalesce(substring(referrer FROM '^[a-z][a-z0-9+.-]*://([^/]+)'), referrer) AS source,
+      count(*)::int AS views
+    FROM page_views
+    WHERE referrer IS NOT NULL AND created_at > now() - make_interval(days => ${days})
+    GROUP BY source ORDER BY views DESC, source LIMIT 10
+  `) as SourceCount[];
+  return rows;
+}
+
+export async function getTopCountries(days: number): Promise<CountryCount[]> {
+  const rows = (await getSql()`
+    SELECT country, count(*)::int AS views
+    FROM page_views
+    WHERE country IS NOT NULL AND created_at > now() - make_interval(days => ${days})
+    GROUP BY country ORDER BY views DESC, country LIMIT 10
+  `) as CountryCount[];
+  return rows;
+}
+
+export async function getAvgDurations(days: number): Promise<PathDuration[]> {
+  const rows = (await getSql()`
+    SELECT path, avg(duration_ms)::int AS avg_ms, count(duration_ms)::int AS samples
+    FROM page_views
+    WHERE duration_ms IS NOT NULL AND created_at > now() - make_interval(days => ${days})
+    GROUP BY path ORDER BY avg_ms DESC LIMIT 10
+  `) as { path: string; avg_ms: number; samples: number }[];
+  return rows.map((r) => ({ path: r.path, avgMs: r.avg_ms, samples: r.samples }));
+}
+
+export async function getRecentSessions(limit: number): Promise<RecentSession[]> {
+  const rows = (await getSql()`
+    SELECT session_id,
+      to_char(min(created_at), 'YYYY-MM-DD HH24:MI') AS started_at,
+      max(country) AS country,
+      array_agg(path ORDER BY created_at, id) AS paths,
+      sum(duration_ms)::int AS total_ms
+    FROM page_views
+    GROUP BY session_id
+    ORDER BY min(created_at) DESC
+    LIMIT ${limit}
+  `) as {
+    session_id: string;
+    started_at: string;
+    country: string | null;
+    paths: string[];
+    total_ms: number | null;
+  }[];
+  return rows.map((r) => ({
+    sessionId: r.session_id,
+    startedAt: r.started_at,
+    country: r.country,
+    paths: r.paths,
+    totalMs: r.total_ms,
+  }));
+}
+
+export interface MessageCounts {
+  total: number;
+  unread: number;
+}
+
+export async function getMessageCounts(): Promise<MessageCounts> {
+  const rows = (await getSql()`
+    SELECT count(*)::int AS total, count(*) FILTER (WHERE NOT read)::int AS unread FROM messages
+  `) as { total: number; unread: number }[];
+  return rows[0];
+}

--- a/jamesduxbury/src/middleware.ts
+++ b/jamesduxbury/src/middleware.ts
@@ -1,0 +1,16 @@
+import { auth, isAdminSession } from '@/auth';
+import type { Session } from 'next-auth';
+import type { NextRequest } from 'next/server';
+
+type AuthedRequest = NextRequest & { auth: Session | null };
+
+export function requireAdmin(req: AuthedRequest): Response | undefined {
+  if (isAdminSession(req.auth)) return undefined;
+  const url = new URL('/signin', req.nextUrl.origin);
+  url.searchParams.set('callbackUrl', req.nextUrl.href);
+  return Response.redirect(url);
+}
+
+export default auth(requireAdmin);
+
+export const config = { matcher: ['/admin/:path*'] };

--- a/jamesduxbury/tests/admin-actions.test.ts
+++ b/jamesduxbury/tests/admin-actions.test.ts
@@ -1,0 +1,222 @@
+import { neon } from '@neondatabase/serverless';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Session } from 'next-auth';
+
+const authMock = vi.fn<() => Promise<Session | null>>();
+vi.mock('@/auth', () => ({
+  auth: () => authMock(),
+  isAdminSession: (s: Session | null) => s?.user?.login === 'jsduxie',
+}));
+
+const revalidated: string[] = [];
+vi.mock('next/cache', () => ({ revalidatePath: (path: string) => revalidated.push(path) }));
+
+// redirect mock throws a sentinel error
+vi.mock('next/navigation', () => ({
+  redirect: (url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  },
+}));
+
+import { deleteItem, markMessageRead, saveItem } from '../src/admin/actions';
+import { countRows, getRow, listRows, makeRoomAt } from '../src/admin/sql';
+import { SITE_ROUTES } from '../src/lib/site';
+
+const sql = neon(process.env.DATABASE_URL!);
+const session: Session = {
+  user: { name: 'James', login: 'jsduxie' },
+  expires: '2099-01-01T00:00:00.000Z',
+};
+const marker = `test-admin-${Date.now()}`;
+const aboutMarker = 9000 + Math.floor(Math.random() * 900);
+const emailMarker = `${marker}@example.com`;
+
+const EMPTY = { message: null, fieldErrors: {} };
+
+function form(entries: Record<string, string | string[]>): FormData {
+  const fd = new FormData();
+  for (const [key, value] of Object.entries(entries)) {
+    for (const v of Array.isArray(value) ? value : [value]) fd.append(key, v);
+  }
+  return fd;
+}
+
+function projectForm(overrides: Record<string, string | string[]> = {}): FormData {
+  return form({
+    title: 'Test project',
+    slug: marker,
+    subtitle: 'integration row',
+    status: 'dev',
+    under_exam: 'on',
+    year_start: '2025',
+    year_end: '2026',
+    tech_stack: 'Vitest, Neon',
+    highlights: ['first highlight', 'second highlight'],
+    'metrics.label': ['F1', 'p-value'],
+    'metrics.value': ['0.9', '< 0.001'],
+    'metrics.ratio': ['0.9', ''],
+    image_path: '',
+    github_link: 'https://github.com/jsduxie/test',
+    live_link: '',
+    sort_order: '950',
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  authMock.mockResolvedValue(session);
+  revalidated.length = 0;
+});
+
+afterAll(async () => {
+  await sql`DELETE FROM projects WHERE slug LIKE 'test-admin-%'`;
+  await sql`DELETE FROM about_paragraphs WHERE sort_order >= 9000`;
+  await sql`DELETE FROM messages WHERE email = ${emailMarker}`;
+});
+
+describe('authorisation', () => {
+  it.each([
+    ['saveItem', () => saveItem('projects', null, EMPTY, projectForm())],
+    ['deleteItem', () => deleteItem('projects', 0)],
+    ['markMessageRead', () => markMessageRead(0)],
+  ])('%s rejects an anonymous caller before touching anything', async (_name, call) => {
+    authMock.mockResolvedValue(null);
+    await expect(call()).rejects.toThrow('Unauthorised');
+  });
+});
+
+describe('validation', () => {
+  it('returns field errors instead of writing', async () => {
+    const state = await saveItem('projects', null, EMPTY, projectForm({ title: '', slug: 'Bad Slug' }));
+    expect(state.message).toBe('Validation failed');
+    expect(state.fieldErrors.title).toBeTruthy();
+    expect(state.fieldErrors.slug).toBe('lowercase letters, digits, and hyphens only');
+    expect(revalidated).toHaveLength(0);
+  });
+
+  it('rejects an out-of-range metric ratio', async () => {
+    const state = await saveItem('projects', null, EMPTY, projectForm({ 'metrics.ratio': ['1.5', ''] }));
+    expect(state.fieldErrors.metrics).toBeTruthy();
+  });
+});
+
+describe('project CRUD round trip', () => {
+  it('creates a row covering every field type', async () => {
+    await expect(saveItem('projects', null, EMPTY, projectForm())).rejects.toThrow(
+      'REDIRECT:/admin/projects',
+    );
+    const [row] = await sql`SELECT * FROM projects WHERE slug = ${marker}`;
+    expect(row.title).toBe('Test project');
+    expect(row.status).toBe('dev');
+    expect(row.under_exam).toBe(true);
+    expect(row.year_start).toBe(2025);
+    expect(row.tech_stack).toEqual(['Vitest', 'Neon']);
+    expect(row.highlights).toEqual(['first highlight', 'second highlight']);
+    expect(row.metrics).toEqual([
+      { label: 'F1', value: '0.9', ratio: 0.9 },
+      { label: 'p-value', value: '< 0.001' },
+    ]);
+    expect(row.image_path).toBeNull();
+    expect(row.github_link).toBe('https://github.com/jsduxie/test');
+    expect(row.live_link).toBeNull();
+    expect(row.sort_order).toBe(950);
+    for (const route of SITE_ROUTES) expect(revalidated).toContain(route);
+    expect(revalidated).toContain('/admin/projects');
+  });
+
+  it('updates the row in place', async () => {
+    const [{ id }] = await sql`SELECT id FROM projects WHERE slug = ${marker}`;
+    await expect(
+      saveItem(
+        'projects',
+        id as number,
+        EMPTY,
+        projectForm({ title: 'Renamed', under_exam: [], 'metrics.label': [], 'metrics.value': [], 'metrics.ratio': [] }),
+      ),
+    ).rejects.toThrow('REDIRECT:/admin/projects');
+    const [row] = await sql`SELECT * FROM projects WHERE id = ${id}`;
+    expect(row.title).toBe('Renamed');
+    expect(row.under_exam).toBe(false);
+    expect(row.metrics).toBeNull();
+  });
+
+  it('surfaces a DB constraint failure as a form message', async () => {
+    const state = await saveItem('projects', null, EMPTY, projectForm({ sort_order: '951' }));
+    expect(state.message).toBeTruthy();
+    expect(state.fieldErrors).toEqual({});
+  });
+
+  it('reads through the admin sql helpers', async () => {
+    const [{ id }] = await sql`SELECT id FROM projects WHERE slug = ${marker}`;
+    const row = await getRow('projects', id as number);
+    expect(row?.title).toBe('Renamed');
+    expect(await getRow('projects', 0)).toBeNull();
+    const rows = await listRows('projects');
+    expect(rows.some((r) => r.id === id)).toBe(true);
+    expect(await countRows('projects')).toBe(rows.length);
+  });
+
+  it('deletes the row', async () => {
+    const [{ id }] = await sql`SELECT id FROM projects WHERE slug = ${marker}`;
+    await deleteItem('projects', id as number);
+    expect(await getRow('projects', id as number)).toBeNull();
+    expect(revalidated).toContain('/admin/projects');
+  });
+});
+
+describe('sort order shifting', () => {
+  it('makes room at a taken position, highest row first', async () => {
+    await sql`
+      INSERT INTO about_paragraphs (runs, sort_order)
+      VALUES ('["shift a"]', ${aboutMarker}), ('["shift b"]', ${aboutMarker + 1})
+    `;
+    // this table has a unique sort_order constraint
+    await makeRoomAt('about_paragraphs', aboutMarker, null);
+    const rows = await sql`
+      SELECT runs, sort_order FROM about_paragraphs WHERE sort_order >= 9000 ORDER BY sort_order
+    `;
+    expect(rows.map((r) => [r.runs[0], r.sort_order])).toEqual([
+      ['shift a', aboutMarker + 1],
+      ['shift b', aboutMarker + 2],
+    ]);
+  });
+
+  it('does nothing when the position is free', async () => {
+    const before = await sql`SELECT id, sort_order FROM about_paragraphs ORDER BY id`;
+    await makeRoomAt('about_paragraphs', 8500, null);
+    const after = await sql`SELECT id, sort_order FROM about_paragraphs ORDER BY id`;
+    expect(after).toEqual(before);
+  });
+
+  it('saving into a taken slot shifts the incumbents down', async () => {
+    await expect(
+      saveItem(
+        'about',
+        null,
+        EMPTY,
+        form({ runs: 'inserted **here**', sort_order: String(aboutMarker + 1) }),
+      ),
+    ).rejects.toThrow('REDIRECT:/admin/about');
+    const rows = await sql`
+      SELECT runs, sort_order FROM about_paragraphs WHERE sort_order >= 9000 ORDER BY sort_order
+    `;
+    expect(rows.map((r) => [r.runs, r.sort_order])).toEqual([
+      [['inserted ', { strong: 'here' }], aboutMarker + 1],
+      [['shift a'], aboutMarker + 2],
+      [['shift b'], aboutMarker + 3],
+    ]);
+  });
+});
+
+describe('messages', () => {
+  it('marks a message as read', async () => {
+    const [{ id }] = await sql`
+      INSERT INTO messages (name, email, message) VALUES ('Test', ${emailMarker}, 'hi')
+      RETURNING id
+    `;
+    await markMessageRead(id as number);
+    const [row] = await sql`SELECT read FROM messages WHERE id = ${id}`;
+    expect(row.read).toBe(true);
+    expect(revalidated).toContain('/admin/messages');
+  });
+});

--- a/jamesduxbury/tests/admin-kit.test.ts
+++ b/jamesduxbury/tests/admin-kit.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from 'vitest';
+import { fieldDefault, parseFields, type FieldDef } from '../src/admin/fields';
+import { parseRuns, serialiseRuns } from '../src/admin/runs';
+import { getSection, SECTIONS } from '../src/admin/sections';
+
+function form(entries: Record<string, string | string[]>): FormData {
+  const fd = new FormData();
+  for (const [key, value] of Object.entries(entries)) {
+    for (const v of Array.isArray(value) ? value : [value]) fd.append(key, v);
+  }
+  return fd;
+}
+
+describe('about runs markup', () => {
+  it('parses plain text, bold, and italic into runs', () => {
+    expect(parseRuns('plain **bold** and *em* end')).toEqual([
+      'plain ',
+      { strong: 'bold' },
+      ' and ',
+      { em: 'em' },
+      ' end',
+    ]);
+  });
+
+  it('round-trips the seeded about paragraphs shape', () => {
+    const runs = [
+      { strong: 'Accredited Member' },
+      ' (AfCIIS) · ',
+      { em: 'FG-HAN' },
+      ' certified.',
+    ];
+    expect(parseRuns(serialiseRuns(runs))).toEqual(runs);
+  });
+
+  it('treats unmatched asterisks as plain text', () => {
+    expect(parseRuns('a * b')).toEqual(['a * b']);
+  });
+});
+
+describe('parseFields', () => {
+  const defs: FieldDef[] = [
+    { column: 'title', label: 'Title', type: 'text' },
+    { column: 'notes', label: 'Notes', type: 'textarea' },
+    { column: 'link', label: 'Link', type: 'url' },
+    { column: 'status', label: 'Status', type: 'select', options: ['live', 'dev'] },
+    { column: 'flag', label: 'Flag', type: 'checkbox' },
+    { column: 'year', label: 'Year', type: 'number' },
+    { column: 'sort_order', label: 'Sort', type: 'sort_order' },
+    { column: 'bullets', label: 'Bullets', type: 'bullets' },
+    { column: 'tags', label: 'Tags', type: 'tags' },
+    { column: 'metrics', label: 'Metrics', type: 'metrics' },
+    { column: 'runs', label: 'Runs', type: 'runs' },
+  ];
+
+  it('maps every field type to its DB value', () => {
+    const fd = form({
+      title: '  Spaced  ',
+      notes: 'line one',
+      link: 'https://example.com',
+      status: 'dev',
+      flag: 'on',
+      year: '2026',
+      sort_order: '3',
+      bullets: ['first', '  ', 'second'],
+      tags: 'a, b , ,c',
+      'metrics.label': ['F1', ''],
+      'metrics.value': ['0.9', ''],
+      'metrics.ratio': ['0.9', ''],
+      runs: 'hello **world**',
+    });
+    expect(parseFields(defs, fd)).toEqual({
+      title: 'Spaced',
+      notes: 'line one',
+      link: 'https://example.com',
+      status: 'dev',
+      flag: true,
+      year: 2026,
+      sort_order: 3,
+      bullets: ['first', 'second'],
+      tags: ['a', 'b', 'c'],
+      metrics: [{ label: 'F1', value: '0.9', ratio: 0.9 }],
+      runs: ['hello ', { strong: 'world' }],
+    });
+  });
+
+  it('maps absent inputs to empty values', () => {
+    expect(parseFields(defs, form({}))).toEqual({
+      title: null,
+      notes: null,
+      link: null,
+      status: null,
+      flag: false,
+      year: null,
+      sort_order: 0,
+      bullets: [],
+      tags: [],
+      metrics: null,
+      runs: [],
+    });
+  });
+
+  it('keeps a metric ratio optional', () => {
+    const fd = form({ 'metrics.label': 'p-value', 'metrics.value': '< 0.001', 'metrics.ratio': '' });
+    expect(parseFields([defs[9]], fd)).toEqual({
+      metrics: [{ label: 'p-value', value: '< 0.001' }],
+    });
+  });
+});
+
+describe('fieldDefault', () => {
+  it('round-trips DB values back into form inputs', () => {
+    const cases: [FieldDef, unknown, unknown][] = [
+      [{ column: 'c', label: 'c', type: 'text' }, 'hello', 'hello'],
+      [{ column: 'c', label: 'c', type: 'text' }, null, ''],
+      [{ column: 'c', label: 'c', type: 'checkbox' }, true, true],
+      [{ column: 'c', label: 'c', type: 'checkbox' }, false, false],
+      [{ column: 'c', label: 'c', type: 'number' }, 2026, '2026'],
+      [{ column: 'c', label: 'c', type: 'number' }, null, ''],
+      [{ column: 'c', label: 'c', type: 'sort_order' }, 0, '0'],
+      [{ column: 'c', label: 'c', type: 'bullets' }, ['a', 'b'], ['a', 'b']],
+      [{ column: 'c', label: 'c', type: 'bullets' }, null, []],
+      [{ column: 'c', label: 'c', type: 'tags' }, ['a', 'b'], 'a, b'],
+      [
+        { column: 'c', label: 'c', type: 'metrics' },
+        [{ label: 'F1', value: '0.9', ratio: 0.9 }, { label: 'p', value: '<1' }],
+        [
+          { label: 'F1', value: '0.9', ratio: '0.9' },
+          { label: 'p', value: '<1', ratio: '' },
+        ],
+      ],
+      [{ column: 'c', label: 'c', type: 'metrics' }, null, []],
+      [{ column: 'c', label: 'c', type: 'runs' }, ['a ', { strong: 'b' }], 'a **b**'],
+    ];
+    for (const [def, dbValue, expected] of cases) {
+      expect(fieldDefault(def, dbValue)).toEqual(expected);
+    }
+  });
+});
+
+describe('section registry', () => {
+  it('exposes the six content sections', () => {
+    expect(SECTIONS.map((s) => s.slug)).toEqual([
+      'projects',
+      'experience',
+      'education',
+      'certifications',
+      'skills',
+      'about',
+    ]);
+  });
+
+  it('throws for an unknown slug', () => {
+    expect(() => getSection('nope')).toThrow('Unknown admin section');
+  });
+
+  const samples: Record<string, Record<string, string | string[]>> = {
+    projects: {
+      title: 'Test',
+      slug: 'test-slug',
+      subtitle: 'sub',
+      status: 'dev',
+      year_start: '2025',
+      year_end: '2026',
+      tech_stack: 'a, b',
+      highlights: ['one'],
+      'metrics.label': 'F1',
+      'metrics.value': '0.9',
+      'metrics.ratio': '0.9',
+      sort_order: '1',
+    },
+    experience: {
+      title: 'Engineer',
+      organisation: 'Org',
+      period: '2025',
+      year_start: '2025',
+      bullets: ['did a thing'],
+      sort_order: '1',
+    },
+    education: {
+      qualification: 'MEng',
+      institution: 'Durham',
+      period: '2022 – 2026',
+      year_end: '2026',
+      sort_order: '1',
+    },
+    certifications: { name: 'Cert', year: '2024', sort_order: '1' },
+    skills: { heading: 'Languages', skills: 'Python, TypeScript', sort_order: '1' },
+    about: { runs: 'plain **bold**', sort_order: '1' },
+  };
+
+  it.each(SECTIONS.map((s) => [s.slug] as const))(
+    '%s: a filled form parses and validates',
+    (slug) => {
+      const section = getSection(slug);
+      const parsed = section.schema.safeParse(parseFields(section.fields, form(samples[slug])));
+      expect(parsed.success).toBe(true);
+    },
+  );
+
+  it.each(SECTIONS.map((s) => [s.slug] as const))('%s: an empty form fails validation', (slug) => {
+    const section = getSection(slug);
+    const parsed = section.schema.safeParse(parseFields(section.fields, form({})));
+    expect(parsed.success).toBe(false);
+  });
+
+  it('labels rows for every section list page', () => {
+    expect(getSection('projects').listLabel({ title: 'FG-HAN' })).toBe('FG-HAN');
+    expect(getSection('experience').listLabel({ title: 'Intern', organisation: 'CTM' })).toBe(
+      'Intern · CTM',
+    );
+    expect(getSection('education').listLabel({ qualification: 'MEng' })).toBe('MEng');
+    expect(getSection('certifications').listLabel({ name: 'ITIL 4' })).toBe('ITIL 4');
+    expect(getSection('skills').listLabel({ heading: 'Languages' })).toBe('Languages');
+    expect(getSection('about').listLabel({ runs: ['plain ', { strong: 'bold' }] })).toBe(
+      'plain bold',
+    );
+  });
+
+  it('truncates long about paragraphs in the list label', () => {
+    const label = getSection('about').listLabel({ runs: ['x'.repeat(120)] });
+    expect(label).toHaveLength(81);
+    expect(label.endsWith('…')).toBe(true);
+  });
+
+  it('rejects an invalid project status and slug', () => {
+    const section = getSection('projects');
+    const bad = { ...samples.projects, status: 'retired', slug: 'Bad Slug' };
+    const parsed = section.schema.safeParse(parseFields(section.fields, form(bad)));
+    expect(parsed.success).toBe(false);
+    const paths = parsed.success ? [] : parsed.error.issues.map((i) => i.path[0]);
+    expect(paths).toContain('status');
+    expect(paths).toContain('slug');
+  });
+
+  it('treats an empty experience year_end as present', () => {
+    const section = getSection('experience');
+    const parsed = section.schema.safeParse(
+      parseFields(section.fields, form(samples.experience)),
+    );
+    expect(parsed.success && parsed.data.year_end).toBeNull();
+  });
+});

--- a/jamesduxbury/tests/admin-ui.dom.test.tsx
+++ b/jamesduxbury/tests/admin-ui.dom.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Session } from 'next-auth';
 import type { FormState } from '../src/admin/actions';
 import type { FieldDef } from '../src/admin/fields';
+import { AutoSubmit } from '../src/components/AutoSubmit';
 import { AdminPanel } from '../src/components/admin/AdminPanel';
 import { DeleteButton } from '../src/components/admin/DeleteButton';
 import { SectionForm } from '../src/components/admin/SectionForm';
@@ -24,6 +25,28 @@ import AdminLayout from '../src/app/admin/layout';
 afterEach(() => {
   authSession.value = null;
   vi.restoreAllMocks();
+});
+
+describe('AutoSubmit', () => {
+  it('submits the named form on mount', () => {
+    const submitSpy = vi
+      .spyOn(HTMLFormElement.prototype, 'requestSubmit')
+      .mockImplementation(() => {});
+    render(
+      <form id="signin-form">
+        <AutoSubmit formId="signin-form" />
+      </form>,
+    );
+    expect(submitSpy).toHaveBeenCalledOnce();
+  });
+
+  it('does nothing when the form is absent', () => {
+    const submitSpy = vi
+      .spyOn(HTMLFormElement.prototype, 'requestSubmit')
+      .mockImplementation(() => {});
+    render(<AutoSubmit formId="missing-form" />);
+    expect(submitSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe('AdminPanel', () => {

--- a/jamesduxbury/tests/admin-ui.dom.test.tsx
+++ b/jamesduxbury/tests/admin-ui.dom.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Session } from 'next-auth';
+import type { FormState } from '../src/admin/actions';
+import type { FieldDef } from '../src/admin/fields';
+import { AdminPanel } from '../src/components/admin/AdminPanel';
+import { DeleteButton } from '../src/components/admin/DeleteButton';
+import { SectionForm } from '../src/components/admin/SectionForm';
+
+const authSession = { value: null as Session | null };
+vi.mock('@/auth', () => ({
+  auth: async () => authSession.value,
+  isAdminSession: (s: Session | null) => s?.user?.login === 'jsduxie',
+}));
+vi.mock('next/navigation', () => ({
+  redirect: (url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  },
+}));
+
+import AdminLayout from '../src/app/admin/layout';
+
+afterEach(() => {
+  authSession.value = null;
+  vi.restoreAllMocks();
+});
+
+describe('AdminPanel', () => {
+  it('renders title, meta, and children', () => {
+    render(
+      <AdminPanel title="projects" meta="3 rows">
+        <p>content</p>
+      </AdminPanel>,
+    );
+    expect(screen.getByText(/projects/)).toBeInTheDocument();
+    expect(screen.getByText('3 rows')).toBeInTheDocument();
+    expect(screen.getByText('content')).toBeInTheDocument();
+  });
+});
+
+describe('DeleteButton', () => {
+  it('asks for confirmation before submitting', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const action = vi.fn();
+    const { container } = render(<DeleteButton action={action} />);
+    fireEvent.submit(container.querySelector('form')!);
+    expect(confirmSpy).toHaveBeenCalledOnce();
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('runs the action when confirmed', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const action = vi.fn(async () => {});
+    const { container } = render(<DeleteButton action={action} />);
+    fireEvent.submit(container.querySelector('form')!);
+    await waitFor(() => expect(action).toHaveBeenCalledOnce());
+  });
+});
+
+describe('SectionForm', () => {
+  const fields: FieldDef[] = [
+    { column: 'title', label: 'Title', type: 'text', help: 'a helpful hint' },
+    { column: 'notes', label: 'Notes', type: 'textarea' },
+    { column: 'link', label: 'Link', type: 'url' },
+    { column: 'status', label: 'Status', type: 'select', options: ['live', 'dev'] },
+    { column: 'flag', label: 'Flag', type: 'checkbox' },
+    { column: 'year', label: 'Year', type: 'number' },
+    { column: 'sort_order', label: 'Sort order', type: 'sort_order' },
+    { column: 'tags', label: 'Tags', type: 'tags' },
+    { column: 'bullets', label: 'Bullets', type: 'bullets' },
+    { column: 'metrics', label: 'Metrics', type: 'metrics' },
+    { column: 'runs', label: 'Paragraph', type: 'runs' },
+  ];
+  const defaults = {
+    title: 'Existing',
+    notes: 'note text',
+    link: 'https://example.com',
+    status: 'dev',
+    flag: true,
+    year: '2026',
+    sort_order: '2',
+    tags: 'a, b',
+    bullets: ['first', 'second'],
+    metrics: [{ label: 'F1', value: '0.9', ratio: '0.9' }],
+    runs: 'plain **bold**',
+  };
+  const noopAction = async (): Promise<FormState> => ({ message: null, fieldErrors: {} });
+
+  it('renders every field type with its default', () => {
+    render(
+      <SectionForm fields={fields} defaults={defaults} action={noopAction} submitLabel="save →" />,
+    );
+    expect(screen.getByLabelText('Title')).toHaveValue('Existing');
+    expect(screen.getByText('a helpful hint')).toBeInTheDocument();
+    expect(screen.getByLabelText('Notes')).toHaveValue('note text');
+    expect(screen.getByLabelText('Link')).toHaveValue('https://example.com');
+    expect(screen.getByLabelText('Status')).toHaveValue('dev');
+    expect(screen.getByLabelText(/Flag/)).toBeChecked();
+    expect(screen.getByLabelText('Year')).toHaveValue(2026);
+    expect(screen.getByLabelText('Sort order')).toHaveValue(2);
+    expect(screen.getByLabelText('Tags')).toHaveValue('a, b');
+    expect(screen.getByDisplayValue('first')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('second')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('F1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Paragraph')).toHaveValue('plain **bold**');
+    expect(screen.getByRole('button', { name: 'save →' })).toBeInTheDocument();
+  });
+
+  it('adds and removes bullet rows', () => {
+    render(
+      <SectionForm fields={fields} defaults={defaults} action={noopAction} submitLabel="save" />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '+ add bullet' }));
+    expect(screen.getAllByDisplayValue('').length).toBeGreaterThanOrEqual(1);
+    const removeButtons = screen.getAllByRole('button', { name: 'remove' });
+    fireEvent.click(removeButtons[0]);
+    expect(screen.queryByDisplayValue('first')).not.toBeInTheDocument();
+  });
+
+  it('keeps typed bullet and metric values in state', () => {
+    render(
+      <SectionForm fields={fields} defaults={defaults} action={noopAction} submitLabel="save" />,
+    );
+    fireEvent.change(screen.getByDisplayValue('first'), { target: { value: 'rewritten' } });
+    expect(screen.getByDisplayValue('rewritten')).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText('label'), { target: { value: 'Recall' } });
+    fireEvent.change(screen.getByPlaceholderText('value'), { target: { value: '0.95' } });
+    fireEvent.change(screen.getByPlaceholderText('ratio'), { target: { value: '0.5' } });
+    expect(screen.getByDisplayValue('Recall')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('0.95')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('0.5')).toBeInTheDocument();
+  });
+
+  it('adds and removes metric rows', () => {
+    render(
+      <SectionForm fields={fields} defaults={defaults} action={noopAction} submitLabel="save" />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '+ add metric' }));
+    expect(screen.getAllByPlaceholderText('label')).toHaveLength(2);
+    const removeButtons = screen.getAllByRole('button', { name: 'remove' });
+    fireEvent.click(removeButtons[removeButtons.length - 1]);
+    expect(screen.getAllByPlaceholderText('label')).toHaveLength(1);
+  });
+
+  it('shows validation errors returned by the action', async () => {
+    const action = vi.fn(
+      async (): Promise<FormState> => ({
+        message: 'Validation failed',
+        fieldErrors: { title: 'Required' },
+      }),
+    );
+    const { container } = render(
+      <SectionForm fields={fields} defaults={defaults} action={action} submitLabel="save" />,
+    );
+    fireEvent.submit(container.querySelector('form')!);
+    expect(await screen.findByText(/Validation failed/)).toBeInTheDocument();
+    expect(screen.getByText(/Required/)).toBeInTheDocument();
+  });
+});
+
+describe('AdminLayout', () => {
+  it('renders the nav for the admin session', async () => {
+    authSession.value = {
+      user: { name: 'James', login: 'jsduxie' },
+      expires: '2099-01-01T00:00:00.000Z',
+    };
+    render(await AdminLayout({ children: <p>page body</p> }));
+    for (const label of ['admin', 'projects', 'about', 'messages', 'analytics', 'sign out']) {
+      expect(screen.getByRole('link', { name: label })).toBeInTheDocument();
+    }
+    expect(screen.getByText('page body')).toBeInTheDocument();
+  });
+
+  it.each([
+    ['anonymous visitor', null],
+    [
+      'non-admin session',
+      { user: { name: 'Someone', login: 'octocat' }, expires: '2099-01-01T00:00:00.000Z' },
+    ],
+  ])('redirects a %s to signin', async (_name, session) => {
+    authSession.value = session;
+    await expect(AdminLayout({ children: null })).rejects.toThrow('REDIRECT:/signin');
+  });
+});

--- a/jamesduxbury/tests/api-visit.test.ts
+++ b/jamesduxbury/tests/api-visit.test.ts
@@ -1,6 +1,15 @@
 import { randomUUID } from 'node:crypto';
 import { neon } from '@neondatabase/serverless';
-import { afterAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+import type { Session } from 'next-auth';
+
+// controls the mocked session for the admin-skip tests
+const authSession = { value: null as Session | null };
+vi.mock('@/auth', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../src/auth')>();
+  return { ...mod, auth: async () => authSession.value };
+});
+
 import { POST } from '../src/app/api/visit/route';
 
 const sql = neon(process.env.DATABASE_URL!);
@@ -13,6 +22,10 @@ function request(body: unknown, headers: Record<string, string> = {}): Request {
     body: JSON.stringify(body),
   });
 }
+
+afterEach(() => {
+  authSession.value = null;
+});
 
 afterAll(async () => {
   await sql`DELETE FROM page_views WHERE session_id = ${sessionId}`;
@@ -62,6 +75,27 @@ describe('POST /api/visit', () => {
     await POST(request({ id, durationMs: 999_999_999_999 }));
     const [row] = await sql`SELECT duration_ms FROM page_views WHERE id = ${id}::bigint`;
     expect(row.duration_ms).toBe(6 * 60 * 60 * 1000);
+  });
+
+  it('skips the signed-in admin without writing', async () => {
+    authSession.value = {
+      user: { name: 'James', login: 'jsduxie' },
+      expires: '2099-01-01T00:00:00.000Z',
+    };
+    const before = await sql`SELECT count(*) AS n FROM page_views WHERE session_id = ${sessionId}`;
+    const res = await POST(request({ sessionId, path: '/' }));
+    expect(res.status).toBe(204);
+    const after = await sql`SELECT count(*) AS n FROM page_views WHERE session_id = ${sessionId}`;
+    expect(after[0].n).toBe(before[0].n);
+  });
+
+  it('still records a non-admin session visit', async () => {
+    authSession.value = {
+      user: { name: 'Someone', login: 'octocat' },
+      expires: '2099-01-01T00:00:00.000Z',
+    };
+    const res = await POST(request({ sessionId, path: '/' }));
+    expect(res.status).toBe(200);
   });
 
   it('skips bot user agents without writing', async () => {

--- a/jamesduxbury/tests/auth.test.ts
+++ b/jamesduxbury/tests/auth.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import type { Session } from 'next-auth';
+import type { NextRequest } from 'next/server';
+import type { JWT } from 'next-auth/jwt';
+import {
+  ALLOWED_LOGIN,
+  auth,
+  authCallbacks,
+  handlers,
+  isAdminSession,
+  isAllowedLogin,
+  signIn,
+  signOut,
+} from '../src/auth';
+import { config, requireAdmin } from '../src/middleware';
+import { GET, POST } from '../src/app/api/auth/[...nextauth]/route';
+
+type AuthedRequest = Parameters<typeof requireAdmin>[0];
+
+function request(href: string, session: Session | null): AuthedRequest {
+  const url = new URL(href);
+  return { auth: session, nextUrl: url } as NextRequest & { auth: Session | null };
+}
+
+function sessionFor(login?: string): Session {
+  return { user: { name: 'James', login }, expires: '2099-01-01T00:00:00.000Z' };
+}
+
+describe('allowlist', () => {
+  it('allows exactly the jsduxie login', () => {
+    expect(ALLOWED_LOGIN).toBe('jsduxie');
+    expect(isAllowedLogin('jsduxie')).toBe(true);
+  });
+
+  it.each(['JSDuxie', 'jsduxie2', 'octocat', '', undefined, null, 42])(
+    'rejects %j',
+    (login) => {
+      expect(isAllowedLogin(login)).toBe(false);
+    },
+  );
+});
+
+describe('isAdminSession', () => {
+  it('accepts only a session carrying the allowed login', () => {
+    expect(isAdminSession(sessionFor('jsduxie'))).toBe(true);
+    expect(isAdminSession(sessionFor('octocat'))).toBe(false);
+    expect(isAdminSession(sessionFor(undefined))).toBe(false);
+    expect(isAdminSession(null)).toBe(false);
+  });
+});
+
+describe('NextAuth wiring', () => {
+  it('exports route handlers and helpers', () => {
+    expect(GET).toBe(handlers.GET);
+    expect(POST).toBe(handlers.POST);
+    expect(typeof auth).toBe('function');
+    expect(typeof signIn).toBe('function');
+    expect(typeof signOut).toBe('function');
+  });
+
+  it('signIn admits only the allowed GitHub profile', () => {
+    expect(authCallbacks.signIn({ profile: { login: 'jsduxie' } })).toBe(true);
+    expect(authCallbacks.signIn({ profile: { login: 'octocat' } })).toBe(false);
+    expect(authCallbacks.signIn({})).toBe(false);
+  });
+
+  it('jwt stores the login at sign-in and keeps it afterwards', () => {
+    const signedIn = authCallbacks.jwt({ token: {}, profile: { login: 'jsduxie' } });
+    expect(signedIn.login).toBe('jsduxie');
+    // later requests carry no profile
+    expect(authCallbacks.jwt({ token: signedIn }).login).toBe('jsduxie');
+  });
+
+  it('session exposes only a string login claim', () => {
+    const run = (token: JWT) =>
+      authCallbacks.session({ session: sessionFor(undefined), token }).user?.login;
+    expect(run({ login: 'jsduxie' })).toBe('jsduxie');
+    expect(run({})).toBeUndefined();
+    expect(run({ login: 42 })).toBeUndefined();
+  });
+});
+
+describe('admin middleware', () => {
+  it('guards exactly the admin subtree', () => {
+    expect(config.matcher).toEqual(['/admin/:path*']);
+  });
+
+  it('lets the allowed account through', () => {
+    expect(
+      requireAdmin(request('http://localhost:3000/admin/projects', sessionFor('jsduxie'))),
+    ).toBeUndefined();
+  });
+
+  it.each([
+    ['anonymous', null],
+    ['wrong account', sessionFor('octocat')],
+    ['session without a login claim', sessionFor(undefined)],
+  ])('redirects a %s request to signin with a callback', (_name, session) => {
+    const res = requireAdmin(request('http://localhost:3000/admin/projects', session));
+    expect(res).toBeInstanceOf(Response);
+    const location = new URL(res!.headers.get('location')!);
+    expect(location.pathname).toBe('/signin');
+    expect(location.searchParams.get('callbackUrl')).toBe('http://localhost:3000/admin/projects');
+  });
+});

--- a/jamesduxbury/tests/db-analytics.test.ts
+++ b/jamesduxbury/tests/db-analytics.test.ts
@@ -1,0 +1,99 @@
+import { randomUUID } from 'node:crypto';
+import { neon } from '@neondatabase/serverless';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  getAvgDurations,
+  getMessageCounts,
+  getRecentSessions,
+  getTopCountries,
+  getTopPaths,
+  getTopReferrers,
+  getViewsPerDay,
+  getVisitTotals,
+} from '../src/db/analytics';
+
+const sql = neon(process.env.DATABASE_URL!);
+const sessionId = randomUUID();
+const pathA = `/test-analytics-a-${Date.now()}`;
+const pathB = `/test-analytics-b-${Date.now()}`;
+
+beforeAll(async () => {
+  // five views, four on pathA, one on pathB, two with durations
+  const rows = [
+    { path: pathA, duration: 30_000, minutesAgo: 5 },
+    { path: pathB, duration: 30_000, minutesAgo: 4 },
+    { path: pathA, duration: null, minutesAgo: 3 },
+    { path: pathA, duration: null, minutesAgo: 2 },
+    { path: pathA, duration: null, minutesAgo: 1 },
+  ];
+  for (const row of rows) {
+    await sql`
+      INSERT INTO page_views (session_id, path, referrer, country, duration_ms, created_at)
+      VALUES (${sessionId}, ${row.path}, 'https://ref.example/some/page', 'ZZ',
+        ${row.duration}, now() - make_interval(mins => ${row.minutesAgo}))
+    `;
+  }
+});
+
+afterAll(async () => {
+  await sql`DELETE FROM page_views WHERE session_id = ${sessionId}`;
+});
+
+describe('analytics queries', () => {
+  it('counts totals across windows', async () => {
+    const totals = await getVisitTotals();
+    expect(totals.last7Days).toBeGreaterThanOrEqual(5);
+    expect(totals.last30Days).toBeGreaterThanOrEqual(totals.last7Days);
+    expect(totals.allTime).toBeGreaterThanOrEqual(totals.last30Days);
+  });
+
+  it('fills every day of the chart window, including zero days', async () => {
+    const days = await getViewsPerDay(30);
+    expect(days).toHaveLength(30);
+    for (const day of days) {
+      expect(day.day).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(day.views).toBeGreaterThanOrEqual(0);
+    }
+    expect(days[days.length - 1].views).toBeGreaterThanOrEqual(5);
+  });
+
+  it('ranks pages by views', async () => {
+    const top = await getTopPaths(30);
+    const ours = top.find((row) => row.path === pathA);
+    expect(ours?.views).toBe(4);
+  });
+
+  it('groups referrers by host', async () => {
+    const top = await getTopReferrers(30);
+    const ours = top.find((row) => row.source === 'ref.example');
+    expect(ours?.views).toBeGreaterThanOrEqual(5);
+  });
+
+  it('ranks countries', async () => {
+    const top = await getTopCountries(30);
+    const ours = top.find((row) => row.country === 'ZZ');
+    expect(ours?.views).toBeGreaterThanOrEqual(5);
+  });
+
+  it('averages duration per path over recorded views only', async () => {
+    const durations = await getAvgDurations(30);
+    const ours = durations.find((row) => row.path === pathA);
+    expect(ours).toEqual({ path: pathA, avgMs: 30_000, samples: 1 });
+  });
+
+  it('returns the session with its path sequence', async () => {
+    const sessions = await getRecentSessions(50);
+    const ours = sessions.find((s) => s.sessionId === sessionId);
+    expect(ours?.paths).toEqual([pathA, pathB, pathA, pathA, pathA]);
+    expect(ours?.country).toBe('ZZ');
+    expect(ours?.totalMs).toBe(60_000);
+    expect(ours?.startedAt).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/);
+  });
+
+  it('counts messages without negative or impossible values', async () => {
+    const counts = await getMessageCounts();
+    expect(counts.total).toBeGreaterThanOrEqual(0);
+    expect(counts.unread).toBeGreaterThanOrEqual(0);
+    expect(counts.unread).toBeLessThanOrEqual(counts.total);
+  });
+});

--- a/jamesduxbury/vitest.config.ts
+++ b/jamesduxbury/vitest.config.ts
@@ -5,13 +5,24 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   plugins: [react()],
   resolve: {
-    alias: { '@': fileURLToPath(new URL('./src', import.meta.url)) },
+    alias: [
+      { find: '@', replacement: fileURLToPath(new URL('./src', import.meta.url)) },
+      // resolves the bare next/server specifier that next-auth imports
+      {
+        find: /^next\/server$/,
+        replacement: fileURLToPath(new URL('./node_modules/next/server.js', import.meta.url)),
+      },
+    ],
   },
   test: {
     globals: true,
+    // inlines next-auth so the next/server alias applies
+    server: { deps: { inline: ['next-auth', '@auth/core'] } },
     // Integration tests run against a remote Neon branch; CI runners need the headroom
     testTimeout: 30_000,
     hookTimeout: 30_000,
+    // runs test files sequentially, several suites share the dev database
+    fileParallelism: false,
     setupFiles: ['./tests/setup.ts'],
     include: ['tests/**/*.test.{ts,tsx}'],
     coverage: {


### PR DESCRIPTION
Closes #15, closes #16, closes #17.

## Auth (#15)

- next-auth v5 (beta) with the GitHub provider, JWT sessions, no DB adapter.
- Only the `jsduxie` GitHub account can sign in. The allowlist is enforced at four layers: the signIn callback, the `/admin/*` middleware, the admin layout, and every server action. The GitHub login is embedded in the JWT and checked by identity, not by session presence.
- Sign-in and sign-out pages; rejected accounts land on `/signin` with an access denied message.

## Admin console (#16)

- Schema-driven form kit: each content section is a field config plus a Zod schema in `src/admin/sections.ts`. Pages, server actions, and SQL are generic across all six sections (projects, experience, education, certifications, skills, about).
- List, create, edit, and delete for every section, plus a messages inbox with mark-as-read.
- Structured editors for metrics (label/value/ratio rows) and bullets (one input per bullet, add/remove). About paragraphs use simple bold/italic markup mapped to the existing runs format.
- Sort order uses insert-at-position semantics: saving a row at a taken position shifts the rows below it down one place.
- Saves revalidate all public routes, so edits go live immediately while normal traffic stays ISR-cached.

## Analytics dashboard (#17)

- `/admin/analytics`: all-time, 30-day, and 7-day totals, a views-per-day chart, top pages, referrers (grouped by host), countries, average time per path, and recent sessions with path sequences.
- The signed-in admin's visits are no longer recorded, enforced server-side in `/api/visit`.

## Testing and validation

- 156 tests in 15 files; coverage 96.5 / 89.3 / 97.0 / 97.1 against the 90/85/90/85 thresholds.
- Allowlist, middleware redirect, action authorisation, validation, CRUD round trips per field type, sort-order shifting, and analytics queries are all covered, including integration tests against the Neon dev branch.
- Format, lint, typecheck, tests, and production build all green. The GitHub sign-in flow was verified manually on localhost.
- CI test and build steps receive dummy auth env vars; no real OAuth runs in CI.
