### PR TITLE
feat(ui): console copy revision, navbar typography, and interaction fixes

### DIFF
--- a/jamesduxbury/package-lock.json
+++ b/jamesduxbury/package-lock.json
@@ -17,6 +17,7 @@
         "nodemailer": "^8.0.7",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "simple-icons": "^16.22.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -7409,6 +7410,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-icons": {
+      "version": "16.22.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-16.22.0.tgz",
+      "integrity": "sha512-/raPcEWh89R2O2IMmHum6W2dF99NNX3yWikVXKUalkDIWz3Rw/S2S+oDPTgJcIGsRh+25m0y8vj4aBaV/KPz3Q==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/simple-icons"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/simple-icons"
+        }
+      ],
+      "license": "CC0-1.0",
+      "engines": {
+        "node": ">=0.12.18"
       }
     },
     "node_modules/source-map-js": {

--- a/jamesduxbury/package.json
+++ b/jamesduxbury/package.json
@@ -27,6 +27,7 @@
     "nodemailer": "^8.0.7",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "simple-icons": "^16.22.0",
     "zod": "^4.4.3"
   },
   "overrides": {

--- a/jamesduxbury/src/app/api/contact/route.ts
+++ b/jamesduxbury/src/app/api/contact/route.ts
@@ -106,7 +106,7 @@ export async function POST(req: Request) {
     return Response.json(
       {
         success: false,
-        error: 'Transmission failed. Please try again later.',
+        error: 'Message failed to send. Please try again later.',
         correlationId,
       },
       { status: 500 },

--- a/jamesduxbury/src/app/contact/page.tsx
+++ b/jamesduxbury/src/app/contact/page.tsx
@@ -22,7 +22,7 @@ export default function ContactPage() {
           ← / home
         </Link>
 
-        <Widget channel="06" label="TRANSMIT" id="contact">
+        <Widget channel="06" label="CONTACT" id="contact">
           <div className="px-4 py-5 sm:px-6">
             <p className="font-mono text-xs uppercase tracking-[0.18em] text-muted">
               {`>`} open channels
@@ -31,7 +31,7 @@ export default function ContactPage() {
           <ContactChannels />
           <div className="px-4 py-5 sm:px-6">
             <p className="font-mono text-xs uppercase tracking-[0.18em] text-muted">
-              {`>`} or transmit a message directly
+              {`>`} or send a message directly
             </p>
           </div>
           <ContactForm />

--- a/jamesduxbury/src/app/opengraph-image.tsx
+++ b/jamesduxbury/src/app/opengraph-image.tsx
@@ -51,7 +51,7 @@ export default function OpenGraphImage() {
         />
         <span style={{ color: colours.live }}>LIVE</span>
         <span style={{ color: colours.border }}>·</span>
-        <span style={{ color: colours.text }}>ENG-CONSOLE</span>
+        <span style={{ color: colours.text }}>JAMES DUXBURY</span>
         <span>v2.0</span>
       </div>
 

--- a/jamesduxbury/src/components/Entry.tsx
+++ b/jamesduxbury/src/components/Entry.tsx
@@ -13,7 +13,6 @@ export const Entry: React.FC = () => {
         <SectionHeader channel="00" label="ENTRY" />
 
         <div className="grid grid-cols-1 gap-8 sm:grid-cols-[auto_1fr] sm:items-start sm:gap-12">
-          {/* profile portrait */}
           <div className="relative h-36 w-36 overflow-hidden border border-border sm:h-40 sm:w-40 lg:h-44 lg:w-44">
             <Image
               src="/images/profile-picture.png"

--- a/jamesduxbury/src/components/Entry.tsx
+++ b/jamesduxbury/src/components/Entry.tsx
@@ -13,7 +13,7 @@ export const Entry: React.FC = () => {
         <SectionHeader channel="00" label="ENTRY" />
 
         <div className="grid grid-cols-1 gap-8 sm:grid-cols-[auto_1fr] sm:items-start sm:gap-12">
-          {/* driver portrait */}
+          {/* profile portrait */}
           <div className="relative h-36 w-36 overflow-hidden border border-border sm:h-40 sm:w-40 lg:h-44 lg:w-44">
             <Image
               src="/images/profile-picture.png"
@@ -32,26 +32,28 @@ export const Entry: React.FC = () => {
 
           {/* spec rows */}
           <div className="divide-y divide-border border-y border-border">
-            <SpecRow label="Driver" trailing={<StatusChip kind="live" label="ACTIVE" />}>
+            <SpecRow label="Name" trailing={<StatusChip kind="live" label="ACTIVE" />}>
               <span className="font-mono text-base text-text sm:text-lg">James Duxbury</span>
               <span className="ml-3 font-mono text-xs uppercase tracking-[0.2em] text-accent">
                 AfCIIS
               </span>
             </SpecRow>
 
-            <SpecRow label="Class">Software engineer · AI &amp; application security</SpecRow>
+            <SpecRow label="Role">Software engineer · AI &amp; application security</SpecRow>
 
-            <SpecRow label="Team">Durham University · Integrated MEng Computer Science</SpecRow>
+            <SpecRow label="Education">
+              Durham University · Integrated MEng Computer Science
+            </SpecRow>
 
             <SpecRow
-              label="Season"
+              label="Years"
               trailing={<span className="font-mono text-xs text-muted">FINAL YEAR</span>}
             >
               <span className="font-mono">2022 — 2026</span>
             </SpecRow>
 
             <SpecRow
-              label="Chassis"
+              label="CV"
               trailing={
                 <Link
                   href="/data/CV.pdf"

--- a/jamesduxbury/src/components/Footer.tsx
+++ b/jamesduxbury/src/components/Footer.tsx
@@ -4,7 +4,7 @@ export function Footer() {
   return (
     <footer
       id="contact"
-      className="border-t border-border bg-bg/60 px-4 py-10 font-mono text-xs text-muted sm:px-6"
+      className="mt-16 border-t border-border bg-bg/60 px-4 py-10 font-mono text-xs text-muted sm:px-6"
     >
       <div className="mx-auto max-w-7xl space-y-6">
         {/* contact line */}

--- a/jamesduxbury/src/components/Footer.tsx
+++ b/jamesduxbury/src/components/Footer.tsx
@@ -1,39 +1,6 @@
 import Link from 'next/link';
 
-interface Contribution {
-  date: string;
-  contributionCount: number;
-}
-
-interface ContributionsResponse {
-  total: { [year: string]: number };
-  contributions: Contribution[];
-}
-
-async function fetchContributions(): Promise<Contribution[] | null> {
-  try {
-    const res = await fetch('https://github-contributions-api.deno.dev/jsduxie.json', {
-      next: { revalidate: 60 * 60 * 6 }, // cache 6h
-    });
-    if (!res.ok) return null;
-    const data: ContributionsResponse = await res.json();
-    return data.contributions.slice(-91); // last ~13 weeks
-  } catch {
-    return null;
-  }
-}
-
-function intensityClass(count: number): string {
-  if (count === 0) return 'bg-border/60';
-  if (count < 3) return 'bg-accent/30';
-  if (count < 6) return 'bg-accent/55';
-  if (count < 10) return 'bg-accent/80';
-  return 'bg-accent';
-}
-
-export async function Footer() {
-  const contributions = await fetchContributions();
-
+export function Footer() {
   return (
     <footer
       id="contact"
@@ -69,28 +36,6 @@ export async function Footer() {
             linkedin ↗
           </Link>
         </div>
-
-        {/* github activity */}
-        {contributions && contributions.length > 0 && (
-          <div>
-            <p className="mb-2 uppercase tracking-[0.18em]">
-              {`>`} github activity · last 13 weeks · @jsduxie
-            </p>
-            <div className="flex gap-[3px]" aria-hidden>
-              {Array.from({ length: Math.ceil(contributions.length / 7) }, (_, weekIdx) => (
-                <div key={weekIdx} className="flex flex-col gap-[3px]">
-                  {contributions.slice(weekIdx * 7, weekIdx * 7 + 7).map((c) => (
-                    <span
-                      key={c.date}
-                      title={`${c.date}: ${c.contributionCount}`}
-                      className={`h-2.5 w-2.5 rounded-[1px] ${intensityClass(c.contributionCount)}`}
-                    />
-                  ))}
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
 
         {/* footer bottom */}
         <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border pt-4 text-[0.65rem] uppercase tracking-[0.18em]">

--- a/jamesduxbury/src/components/Footer.tsx
+++ b/jamesduxbury/src/components/Footer.tsx
@@ -95,7 +95,7 @@ export async function Footer() {
         {/* footer bottom */}
         <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border pt-4 text-[0.65rem] uppercase tracking-[0.18em]">
           <span>
-            {`>`} eng-console · v2.0 · last build {new Date().getFullYear()}
+            {`>`} jamesduxbury.com · v2.0 · last build {new Date().getFullYear()}
           </span>
           <span>
             {`> built with`} <span className="text-accent">next.js</span> · vercel

--- a/jamesduxbury/src/components/about/AboutDetail.tsx
+++ b/jamesduxbury/src/components/about/AboutDetail.tsx
@@ -5,7 +5,7 @@ import { renderRun } from './renderRun';
 export async function AboutDetail() {
   const aboutParagraphs = await getAboutParagraphs();
   return (
-    <Widget channel="01" label="TRANSMISSION" id="about">
+    <Widget channel="01" label="ABOUT" id="about">
       <div className="space-y-4 px-4 py-6 text-base leading-relaxed text-text/85 sm:px-6 sm:text-lg">
         {aboutParagraphs.map((paragraph, i) => (
           <p key={i}>{paragraph.map(renderRun)}</p>

--- a/jamesduxbury/src/components/about/AboutDetail.tsx
+++ b/jamesduxbury/src/components/about/AboutDetail.tsx
@@ -6,7 +6,7 @@ export async function AboutDetail() {
   const aboutParagraphs = await getAboutParagraphs();
   return (
     <Widget channel="01" label="ABOUT" id="about">
-      <div className="space-y-4 px-4 py-6 text-base leading-relaxed text-text/85 sm:px-6 sm:text-lg">
+      <div className="space-y-4 px-4 py-6 text-sm leading-relaxed text-text/85 sm:px-6">
         {aboutParagraphs.map((paragraph, i) => (
           <p key={i}>{paragraph.map(renderRun)}</p>
         ))}

--- a/jamesduxbury/src/components/about/AboutSummary.tsx
+++ b/jamesduxbury/src/components/about/AboutSummary.tsx
@@ -7,6 +7,7 @@ const SUMMARY_COUNT = 2;
 
 export async function AboutSummary() {
   const aboutParagraphs = await getAboutParagraphs();
+  const remaining = Math.max(aboutParagraphs.length - SUMMARY_COUNT, 0);
   return (
     <Widget channel="01" label="ABOUT" id="about">
       <div className="space-y-4 px-4 py-5 text-sm leading-relaxed text-text/85 sm:px-6 sm:text-base">
@@ -18,7 +19,7 @@ export async function AboutSummary() {
         href="/about"
         className="group flex items-center justify-between border-t border-border bg-bg/40 px-4 py-3 font-mono text-sm uppercase tracking-[0.18em] text-accent transition-colors hover:bg-accent/10 sm:px-6"
       >
-        <span>+ {aboutParagraphs.length - SUMMARY_COUNT} more paragraphs</span>
+        <span>{remaining > 0 ? `+ ${remaining} more paragraphs` : 'read more'}</span>
         <span className="transition-transform group-hover:translate-x-1">open /about →</span>
       </Link>
     </Widget>

--- a/jamesduxbury/src/components/about/AboutSummary.tsx
+++ b/jamesduxbury/src/components/about/AboutSummary.tsx
@@ -10,7 +10,7 @@ export async function AboutSummary() {
   const remaining = Math.max(aboutParagraphs.length - SUMMARY_COUNT, 0);
   return (
     <Widget channel="01" label="ABOUT" id="about">
-      <div className="space-y-4 px-4 py-5 text-sm leading-relaxed text-text/85 sm:px-6 sm:text-base">
+      <div className="space-y-4 px-4 py-5 text-sm leading-relaxed text-text/85 sm:px-6">
         {aboutParagraphs.slice(0, SUMMARY_COUNT).map((paragraph, i) => (
           <p key={i}>{paragraph.map(renderRun)}</p>
         ))}

--- a/jamesduxbury/src/components/about/AboutSummary.tsx
+++ b/jamesduxbury/src/components/about/AboutSummary.tsx
@@ -8,7 +8,7 @@ const SUMMARY_COUNT = 2;
 export async function AboutSummary() {
   const aboutParagraphs = await getAboutParagraphs();
   return (
-    <Widget channel="01" label="TRANSMISSION" id="about">
+    <Widget channel="01" label="ABOUT" id="about">
       <div className="space-y-4 px-4 py-5 text-sm leading-relaxed text-text/85 sm:px-6 sm:text-base">
         {aboutParagraphs.slice(0, SUMMARY_COUNT).map((paragraph, i) => (
           <p key={i}>{paragraph.map(renderRun)}</p>

--- a/jamesduxbury/src/components/console/CollapsibleRow.tsx
+++ b/jamesduxbury/src/components/console/CollapsibleRow.tsx
@@ -6,21 +6,35 @@ import { AnimatePresence, motion } from 'framer-motion';
 interface CollapsibleRowProps {
   header: React.ReactNode;
   defaultOpen?: boolean;
+  open?: boolean;
+  onToggle?: () => void;
   children: React.ReactNode;
 }
 
 export const CollapsibleRow: React.FC<CollapsibleRowProps> = ({
   header,
   defaultOpen = false,
+  open: controlledOpen,
+  onToggle,
   children,
 }) => {
-  const [open, setOpen] = useState(defaultOpen);
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : internalOpen;
+
+  const toggle = () => {
+    if (isControlled) {
+      onToggle?.();
+    } else {
+      setInternalOpen((v) => !v);
+    }
+  };
 
   return (
     <div className="border-b border-border last:border-b-0">
       <button
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={toggle}
         aria-expanded={open}
         className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-bg/40 sm:px-6"
       >

--- a/jamesduxbury/src/components/console/StatusBar.tsx
+++ b/jamesduxbury/src/components/console/StatusBar.tsx
@@ -55,7 +55,7 @@ export const StatusBar: React.FC = () => {
         </Link>
 
         {/* right — desktop nav */}
-        <nav className="hidden items-center gap-6 font-mono text-sm lg:flex">
+        <nav className="hidden items-center gap-6 font-mono text-sm uppercase tracking-[0.18em] lg:flex">
           {NAV_LINKS.map((link) => {
             const active = isActive(pathname, link.href);
             return (
@@ -96,7 +96,7 @@ export const StatusBar: React.FC = () => {
           aria-label="Open menu"
           aria-expanded={isMenuOpen}
           onClick={() => setIsMenuOpen(!isMenuOpen)}
-          className="font-mono text-xs uppercase tracking-[0.2em] text-muted hover:text-accent lg:hidden"
+          className="font-mono text-sm uppercase tracking-[0.18em] text-muted hover:text-accent lg:hidden"
         >
           menu
         </button>
@@ -105,7 +105,7 @@ export const StatusBar: React.FC = () => {
       {/* mobile menu */}
       {isMenuOpen && (
         <nav className="border-t border-border bg-bg px-6 py-4 lg:hidden">
-          <ul className="flex flex-col gap-3 font-mono text-sm">
+          <ul className="flex flex-col gap-3 font-mono text-sm uppercase tracking-[0.18em]">
             {NAV_LINKS.map((link) => {
               const active = isActive(pathname, link.href);
               return (

--- a/jamesduxbury/src/components/console/StatusBar.tsx
+++ b/jamesduxbury/src/components/console/StatusBar.tsx
@@ -48,7 +48,7 @@ export const StatusBar: React.FC = () => {
             LIVE
           </span>
           <span className="text-border">·</span>
-          <span className="hidden text-text sm:inline">ENG-CONSOLE</span>
+          <span className="hidden text-text sm:inline">JAMES DUXBURY</span>
           <span className="hidden text-muted sm:inline">v2.0</span>
           <span className="text-border sm:hidden">·</span>
           <span className="text-muted sm:hidden">{session}</span>

--- a/jamesduxbury/src/components/contact/ContactForm.tsx
+++ b/jamesduxbury/src/components/contact/ContactForm.tsx
@@ -33,12 +33,15 @@ export const ContactForm: React.FC = () => {
         setMessage('');
       } else {
         const data = (await res.json().catch(() => ({}))) as { error?: string };
-        setState({ kind: 'error', message: data.error ?? `Transmission failed (${res.status})` });
+        setState({
+          kind: 'error',
+          message: data.error ?? `Message failed to send (${res.status})`,
+        });
       }
     } catch (err) {
       setState({
         kind: 'error',
-        message: err instanceof Error ? err.message : 'Transmission failed.',
+        message: err instanceof Error ? err.message : 'Message failed to send.',
       });
     }
   };
@@ -85,7 +88,7 @@ export const ContactForm: React.FC = () => {
 
       <div className="px-4 py-5 sm:px-6">
         <label htmlFor="contact-message" className={fieldLabel}>
-          Transmission · Message
+          Message
         </label>
         <textarea
           id="contact-message"
@@ -102,7 +105,7 @@ export const ContactForm: React.FC = () => {
       <div className="flex flex-col items-stretch gap-3 px-4 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-6">
         <div className="font-mono text-xs uppercase tracking-[0.18em] text-muted">
           {state.kind === 'success' && (
-            <span className="text-live">{`>`} transmission acknowledged · thank you</span>
+            <span className="text-live">{`>`} message sent · thank you</span>
           )}
           {state.kind === 'error' && (
             <span className="text-danger">
@@ -110,14 +113,14 @@ export const ContactForm: React.FC = () => {
             </span>
           )}
           {state.kind === 'idle' && <span>{`>`} signal will be routed to a secure inbox</span>}
-          {state.kind === 'sending' && <span>{`>`} transmitting…</span>}
+          {state.kind === 'sending' && <span>{`>`} sending…</span>}
         </div>
         <button
           type="submit"
           disabled={state.kind === 'sending'}
           className="rounded-full border border-accent bg-accent/10 px-5 py-2 font-mono text-sm uppercase tracking-[0.18em] text-accent transition-colors hover:bg-accent hover:text-text disabled:cursor-not-allowed disabled:opacity-60"
         >
-          {state.kind === 'sending' ? 'sending…' : 'transmit →'}
+          {state.kind === 'sending' ? 'sending…' : 'send →'}
         </button>
       </div>
     </form>

--- a/jamesduxbury/src/components/education/DegreeCard.tsx
+++ b/jamesduxbury/src/components/education/DegreeCard.tsx
@@ -4,9 +4,16 @@ import { CollapsibleRow } from '@/components/console/CollapsibleRow';
 interface DegreeCardProps {
   degree: Degree;
   defaultOpen?: boolean;
+  open?: boolean;
+  onToggle?: () => void;
 }
 
-export const DegreeCard: React.FC<DegreeCardProps> = ({ degree, defaultOpen = false }) => {
+export const DegreeCard: React.FC<DegreeCardProps> = ({
+  degree,
+  defaultOpen = false,
+  open,
+  onToggle,
+}) => {
   const header = (
     <div className="space-y-1">
       <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
@@ -33,7 +40,7 @@ export const DegreeCard: React.FC<DegreeCardProps> = ({ degree, defaultOpen = fa
   }
 
   return (
-    <CollapsibleRow header={header} defaultOpen={defaultOpen}>
+    <CollapsibleRow header={header} defaultOpen={defaultOpen} open={open} onToggle={onToggle}>
       <ul className="ml-4 list-disc space-y-2 pl-2 text-sm leading-relaxed text-text/85">
         {degree.bullets.map((b, i) => (
           <li key={i}>{b}</li>

--- a/jamesduxbury/src/components/education/DegreeList.tsx
+++ b/jamesduxbury/src/components/education/DegreeList.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useState } from 'react';
+import type { Degree } from '@/data/education';
+import { DegreeCard } from './DegreeCard';
+
+interface DegreeListProps {
+  degrees: Degree[];
+}
+
+export const DegreeList: React.FC<DegreeListProps> = ({ degrees }) => {
+  const [openIndex, setOpenIndex] = useState(0);
+
+  return (
+    <>
+      {degrees.map((degree, i) => (
+        <DegreeCard
+          key={degree.qualification}
+          degree={degree}
+          open={openIndex === i}
+          onToggle={() => setOpenIndex((prev) => (prev === i ? -1 : i))}
+        />
+      ))}
+    </>
+  );
+};

--- a/jamesduxbury/src/components/education/EducationDetail.tsx
+++ b/jamesduxbury/src/components/education/EducationDetail.tsx
@@ -1,5 +1,5 @@
 import { Widget } from '@/components/console/Widget';
-import { DegreeCard } from './DegreeCard';
+import { DegreeList } from './DegreeList';
 import { CertificationsBlock } from './CertificationsBlock';
 import { getDegrees } from '@/db/queries';
 
@@ -7,9 +7,7 @@ export async function EducationDetail() {
   const degrees = await getDegrees();
   return (
     <Widget channel="05" label="EDUCATION" count={degrees.length} id="education">
-      {degrees.map((d, i) => (
-        <DegreeCard key={d.qualification} degree={d} defaultOpen={i === 0} />
-      ))}
+      <DegreeList degrees={degrees} />
       <CertificationsBlock />
     </Widget>
   );

--- a/jamesduxbury/src/components/education/EducationSummary.tsx
+++ b/jamesduxbury/src/components/education/EducationSummary.tsx
@@ -16,7 +16,9 @@ export async function EducationSummary() {
         href="/education"
         className="group flex items-center justify-between border-t border-border bg-bg/40 px-4 py-3 font-mono text-sm uppercase tracking-[0.18em] text-accent transition-colors hover:bg-accent/10 sm:px-6"
       >
-        <span>+ {certifications.length} certifications</span>
+        <span>
+          {certifications.length > 0 ? `+ ${certifications.length} certifications` : 'view all'}
+        </span>
         <span className="transition-transform group-hover:translate-x-1">open /education →</span>
       </Link>
     </Widget>

--- a/jamesduxbury/src/components/experience/ExperienceDetail.tsx
+++ b/jamesduxbury/src/components/experience/ExperienceDetail.tsx
@@ -1,14 +1,12 @@
 import { Widget } from '@/components/console/Widget';
-import { RoleCard } from './RoleCard';
+import { RoleList } from './RoleList';
 import { getRoles } from '@/db/queries';
 
 export async function ExperienceDetail() {
   const roles = await getRoles();
   return (
     <Widget channel="04" label="EXPERIENCE" count={roles.length} id="experience">
-      {roles.map((role, i) => (
-        <RoleCard key={`${role.organisation}-${role.period}`} role={role} defaultOpen={i === 0} />
-      ))}
+      <RoleList roles={roles} />
     </Widget>
   );
 }

--- a/jamesduxbury/src/components/experience/RoleCard.tsx
+++ b/jamesduxbury/src/components/experience/RoleCard.tsx
@@ -4,9 +4,16 @@ import { CollapsibleRow } from '@/components/console/CollapsibleRow';
 interface RoleCardProps {
   role: Role;
   defaultOpen?: boolean;
+  open?: boolean;
+  onToggle?: () => void;
 }
 
-export const RoleCard: React.FC<RoleCardProps> = ({ role, defaultOpen = false }) => {
+export const RoleCard: React.FC<RoleCardProps> = ({
+  role,
+  defaultOpen = false,
+  open,
+  onToggle,
+}) => {
   const isCurrent = role.yearEnd === 'present';
 
   const header = (
@@ -41,7 +48,7 @@ export const RoleCard: React.FC<RoleCardProps> = ({ role, defaultOpen = false })
   }
 
   return (
-    <CollapsibleRow header={header} defaultOpen={defaultOpen}>
+    <CollapsibleRow header={header} defaultOpen={defaultOpen} open={open} onToggle={onToggle}>
       <ul className="ml-4 list-disc space-y-2 pl-2 text-sm leading-relaxed text-text/85">
         {role.bullets.map((b, i) => (
           <li key={i}>{b}</li>

--- a/jamesduxbury/src/components/experience/RoleList.tsx
+++ b/jamesduxbury/src/components/experience/RoleList.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useState } from 'react';
+import type { Role } from '@/data/experience';
+import { RoleCard } from './RoleCard';
+
+interface RoleListProps {
+  roles: Role[];
+}
+
+export const RoleList: React.FC<RoleListProps> = ({ roles }) => {
+  const [openIndex, setOpenIndex] = useState(0);
+
+  return (
+    <>
+      {roles.map((role, i) => (
+        <RoleCard
+          key={`${role.organisation}-${role.period}`}
+          role={role}
+          open={openIndex === i}
+          onToggle={() => setOpenIndex((prev) => (prev === i ? -1 : i))}
+        />
+      ))}
+    </>
+  );
+};

--- a/jamesduxbury/src/components/skills/SkillIconBadge.tsx
+++ b/jamesduxbury/src/components/skills/SkillIconBadge.tsx
@@ -1,0 +1,16 @@
+import { getSkillIcon } from './skillIcon';
+
+export function SkillIconBadge({ name }: { name: string }) {
+  const icon = getSkillIcon(name);
+  if (!icon) return null;
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className="h-[1em] w-[1em] shrink-0"
+    >
+      <path d={icon.path} />
+    </svg>
+  );
+}

--- a/jamesduxbury/src/components/skills/SkillsDetail.tsx
+++ b/jamesduxbury/src/components/skills/SkillsDetail.tsx
@@ -1,5 +1,6 @@
 import { Widget } from '@/components/console/Widget';
 import { getSkillGroups } from '@/db/queries';
+import { SkillIconBadge } from './SkillIconBadge';
 
 export async function SkillsDetail() {
   const skillGroups = await getSkillGroups();
@@ -16,7 +17,8 @@ export async function SkillsDetail() {
             </div>
             <div className="mt-3 flex flex-wrap gap-2">
               {group.skills.map((skill) => (
-                <span key={skill} className="skill-badge">
+                <span key={skill} className="skill-badge inline-flex items-center gap-1.5">
+                  <SkillIconBadge name={skill} />
                   {skill}
                 </span>
               ))}

--- a/jamesduxbury/src/components/skills/SkillsSummary.tsx
+++ b/jamesduxbury/src/components/skills/SkillsSummary.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { Widget } from '@/components/console/Widget';
 import { getSkillGroups } from '@/db/queries';
+import { SkillIconBadge } from './SkillIconBadge';
 
 export async function SkillsSummary() {
   const skillGroups = await getSkillGroups();
@@ -17,9 +18,15 @@ export async function SkillsSummary() {
                 {group.skills.length} item{group.skills.length === 1 ? '' : 's'}
               </span>
             </div>
-            <p className="mt-1 font-mono text-xs text-muted">
-              {group.skills.slice(0, 4).join(' · ')}
-              {group.skills.length > 4 ? ` · +${group.skills.length - 4}` : ''}
+            <p className="mt-1 flex flex-wrap items-center gap-x-1.5 gap-y-1 font-mono text-xs text-muted">
+              {group.skills.slice(0, 4).map((skill, index) => (
+                <span key={skill} className="inline-flex items-center gap-1">
+                  {index > 0 ? <span aria-hidden="true">·</span> : null}
+                  <SkillIconBadge name={skill} />
+                  {skill}
+                </span>
+              ))}
+              {group.skills.length > 4 ? <span>· +{group.skills.length - 4}</span> : null}
             </p>
           </div>
         ))}

--- a/jamesduxbury/src/components/skills/skillIcon.ts
+++ b/jamesduxbury/src/components/skills/skillIcon.ts
@@ -1,0 +1,41 @@
+import * as simpleIcons from 'simple-icons';
+
+export interface SkillIcon {
+  title: string;
+  path: string;
+}
+
+interface SimpleIcon {
+  title: string;
+  slug: string;
+  path: string;
+}
+
+type IconRegistry = Record<string, SimpleIcon | undefined>;
+
+// names whose stripped slug collides with another icon or does not match the export key
+const slugOverrides: Record<string, string> = {
+  'Node.js': 'nodedotjs',
+  'C++': 'cplusplus',
+  'GitLab CI/CD': 'gitlab',
+};
+
+// names that strip down to an unrelated icon's slug and have no icon of their own
+const suppressed = new Set<string>(['C#']);
+
+function defaultSlug(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function exportKey(slug: string): string {
+  return 'si' + slug.charAt(0).toUpperCase() + slug.slice(1);
+}
+
+export function getSkillIcon(name: string): SkillIcon | null {
+  if (suppressed.has(name)) return null;
+  const slug = slugOverrides[name] ?? defaultSlug(name);
+  const registry = simpleIcons as unknown as IconRegistry;
+  const icon = registry[exportKey(slug)];
+  if (!icon) return null;
+  return { title: icon.title, path: icon.path };
+}

--- a/jamesduxbury/tests/components.dom.test.tsx
+++ b/jamesduxbury/tests/components.dom.test.tsx
@@ -52,6 +52,16 @@ describe('detail components render seeded DB content', () => {
     }
   });
 
+  it('SkillsDetail renders an icon for a known skill', async () => {
+    const { container } = render(await SkillsDetail());
+    const badge = screen
+      .getAllByText('TypeScript')
+      .map((el) => el.closest('.skill-badge'))
+      .find((el): el is HTMLElement => el !== null);
+    expect(badge?.querySelector('svg')).not.toBeNull();
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
   it('AboutDetail renders styled runs from jsonb', async () => {
     render(await AboutDetail());
     const strong = screen.getByText('Artificial Intelligence and application security');

--- a/jamesduxbury/tests/skill-icon.test.ts
+++ b/jamesduxbury/tests/skill-icon.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { getSkillIcon } from '../src/components/skills/skillIcon';
+
+describe('getSkillIcon', () => {
+  it('resolves a cleanly slugified name', () => {
+    const icon = getSkillIcon('TypeScript');
+    expect(icon).not.toBeNull();
+    expect(icon?.title).toBe('TypeScript');
+    expect(icon?.path.length).toBeGreaterThan(0);
+  });
+
+  it('resolves a name via the override map', () => {
+    const icon = getSkillIcon('Node.js');
+    expect(icon).not.toBeNull();
+    expect(icon?.title).toBe('Node.js');
+  });
+
+  it('returns null for an unknown name', () => {
+    expect(getSkillIcon('Definitely Not A Real Skill')).toBeNull();
+  });
+
+  it('returns null for a suppressed collision name', () => {
+    expect(getSkillIcon('C#')).toBeNull();
+  });
+});

--- a/jamesduxbury/tests/summary-empty.dom.test.tsx
+++ b/jamesduxbury/tests/summary-empty.dom.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/db/queries', () => ({
+  getAboutParagraphs: vi.fn(async () => []),
+  getDegrees: vi.fn(async () => []),
+  getCertifications: vi.fn(async () => []),
+}));
+
+import { AboutSummary } from '../src/components/about/AboutSummary';
+import { EducationSummary } from '../src/components/education/EducationSummary';
+
+describe('summary footers with no extra content', () => {
+  it('AboutSummary hides the paragraph count when empty', async () => {
+    render(await AboutSummary());
+    expect(screen.queryByText(/more paragraphs/)).toBeNull();
+    expect(screen.queryByText(/-\d/)).toBeNull();
+    expect(screen.getByText('read more')).toBeInTheDocument();
+  });
+
+  it('EducationSummary hides the certification count when empty', async () => {
+    render(await EducationSummary());
+    expect(screen.queryByText(/certifications/)).toBeNull();
+    expect(screen.getByText('view all')).toBeInTheDocument();
+  });
+});

--- a/jamesduxbury/tests/ui.dom.test.tsx
+++ b/jamesduxbury/tests/ui.dom.test.tsx
@@ -56,44 +56,10 @@ describe('Entry', () => {
 });
 
 describe('Footer', () => {
-  beforeEach(() => {
-    fetchMock.mockReset();
-    vi.stubGlobal('fetch', fetchMock);
-  });
-  afterEach(() => vi.unstubAllGlobals());
-
-  // Counts chosen to hit every intensity band: 0, <3, <6, <10, >=10
-  const contributions = Array.from({ length: 91 }, (_, i) => ({
-    date: `2026-0${(i % 9) + 1}-0${(i % 9) + 1}-${i}`,
-    contributionCount: [0, 2, 5, 7, 11][i % 5],
-  }));
-
-  it('renders the contribution grid across all intensity bands', async () => {
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => ({ total: {}, contributions }),
-    });
-    const { container } = render(await Footer());
-    expect(screen.getByText(/github activity/)).toBeInTheDocument();
-    const cells = [...container.querySelectorAll('span[title]')];
-    expect(cells).toHaveLength(91);
-    const tokens = new Set(cells.flatMap((c) => c.className.split(' ')));
-    for (const cls of ['bg-border/60', 'bg-accent/30', 'bg-accent/55', 'bg-accent/80', 'bg-accent']) {
-      expect(tokens).toContain(cls);
-    }
-  });
-
-  it('omits the grid when the contributions API fails', async () => {
-    fetchMock.mockResolvedValue({ ok: false });
-    render(await Footer());
-    expect(screen.queryByText(/github activity/)).toBeNull();
-  });
-
-  it('omits the grid when the contributions API is unreachable', async () => {
-    fetchMock.mockRejectedValue(new Error('offline'));
-    render(await Footer());
-    expect(screen.queryByText(/github activity/)).toBeNull();
+  it('renders the contact links', () => {
+    render(<Footer />);
     expect(screen.getByText('contact form ↗')).toBeInTheDocument();
+    expect(screen.getByText('email ↗')).toBeInTheDocument();
   });
 });
 

--- a/jamesduxbury/tests/ui.dom.test.tsx
+++ b/jamesduxbury/tests/ui.dom.test.tsx
@@ -11,6 +11,7 @@ import { StatusBar } from '../src/components/console/StatusBar';
 import { MetricBar } from '../src/components/work/MetricBar';
 import { ProjectRow } from '../src/components/work/ProjectRow';
 import { DegreeCard } from '../src/components/education/DegreeCard';
+import { DegreeList } from '../src/components/education/DegreeList';
 import { ContactForm } from '../src/components/contact/ContactForm';
 import { ContactChannels } from '../src/components/contact/ContactChannels';
 import { WorkSummary } from '../src/components/work/WorkSummary';
@@ -196,5 +197,38 @@ describe('presentational edge cases', () => {
     const toggle = screen.getByRole('button');
     fireEvent.click(toggle);
     expect(screen.getAllByText(degrees[0].bullets![0]).length).toBeGreaterThan(0);
+  });
+});
+
+describe('single-open accordion', () => {
+  it('opens the first item by default and keeps at most one open', async () => {
+    render(<DegreeList degrees={degrees} />);
+    const toggles = screen.getAllByRole('button');
+
+    expect(toggles[0]).toHaveAttribute('aria-expanded', 'true');
+    expect(toggles[1]).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(toggles[1]);
+
+    await waitFor(() => {
+      expect(toggles[1]).toHaveAttribute('aria-expanded', 'true');
+      expect(toggles[0]).toHaveAttribute('aria-expanded', 'false');
+    });
+    expect(
+      screen.getAllByRole('button').filter((b) => b.getAttribute('aria-expanded') === 'true'),
+    ).toHaveLength(1);
+  });
+
+  it('toggles an open item closed so none remain open', async () => {
+    render(<DegreeList degrees={degrees} />);
+    const toggles = screen.getAllByRole('button');
+
+    fireEvent.click(toggles[0]);
+
+    await waitFor(() =>
+      expect(
+        screen.getAllByRole('button').filter((b) => b.getAttribute('aria-expanded') === 'true'),
+      ).toHaveLength(0),
+    );
   });
 });

--- a/jamesduxbury/tests/ui.dom.test.tsx
+++ b/jamesduxbury/tests/ui.dom.test.tsx
@@ -142,8 +142,8 @@ describe('ContactForm', () => {
     fetchMock.mockResolvedValue({ ok: true });
     render(<ContactForm />);
     fill();
-    fireEvent.submit(screen.getByRole('button', { name: /transmit/ }).closest('form')!);
-    await waitFor(() => expect(screen.getByText(/transmission acknowledged/)).toBeInTheDocument());
+    fireEvent.submit(screen.getByRole('button', { name: /send/ }).closest('form')!);
+    await waitFor(() => expect(screen.getByText(/message sent/)).toBeInTheDocument());
     expect(screen.getByLabelText('Name')).toHaveValue('');
   });
 
@@ -151,7 +151,7 @@ describe('ContactForm', () => {
     fetchMock.mockResolvedValue({ ok: false, status: 400, json: async () => ({ error: 'Invalid payload' }) });
     render(<ContactForm />);
     fill();
-    fireEvent.submit(screen.getByRole('button', { name: /transmit/ }).closest('form')!);
+    fireEvent.submit(screen.getByRole('button', { name: /send/ }).closest('form')!);
     await waitFor(() => expect(screen.getByText(/Invalid payload/)).toBeInTheDocument());
   });
 
@@ -159,8 +159,8 @@ describe('ContactForm', () => {
     fetchMock.mockResolvedValue({ ok: false, status: 500, json: async () => Promise.reject(new Error('no body')) });
     render(<ContactForm />);
     fill();
-    fireEvent.submit(screen.getByRole('button', { name: /transmit/ }).closest('form')!);
-    await waitFor(() => expect(screen.getByText(/Transmission failed \(500\)/)).toBeInTheDocument());
+    fireEvent.submit(screen.getByRole('button', { name: /send/ }).closest('form')!);
+    await waitFor(() => expect(screen.getByText(/Message failed to send \(500\)/)).toBeInTheDocument());
   });
 
   it('shows network failures and disables the button while sending', async () => {
@@ -168,7 +168,7 @@ describe('ContactForm', () => {
     fetchMock.mockReturnValue(new Promise((_, rej) => (reject = rej)));
     render(<ContactForm />);
     fill();
-    fireEvent.submit(screen.getByRole('button', { name: /transmit/ }).closest('form')!);
+    fireEvent.submit(screen.getByRole('button', { name: /send/ }).closest('form')!);
     await waitFor(() => expect(screen.getByRole('button', { name: /sending/ })).toBeDisabled());
     reject!(new Error('network down'));
     await waitFor(() => expect(screen.getByText(/network down/)).toBeInTheDocument());


### PR DESCRIPTION
This revises the site console copy, navbar typography, and several interaction details.

- Updated navbar typography
- Replaced console metaphor terms with standard labels
- Guarded summary counts so they hide when there is no extra content
- Added spacing between page content and footer
- Removed the GitHub activity graph from the footer
- Rendered per-skill icons via simple-icons
- Made experience and education accordions single-open
- Aligned about body text with experience and education

Closes #23