### PR TITLE
fix(ci): serialise db-touching ci runs with a concurrency group

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,10 @@ defaults:
 
 jobs:
   check:
+    # serialise runs so concurrent suites never share the neon dev branch
+    concurrency:
+      group: neon-dev-db
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Two CI runs triggered seconds apart (a pull_request run and the push run from the same rebase merge) ran the test suite against the same Neon dev branch at the same time. One run's integration tests changed table counts while the other run's seed idempotency test was counting, which failed PR #26's run.

This adds a concurrency group to the check job so runs that touch the dev database queue instead of overlapping. cancel-in-progress is false, so an in-flight run completes and the newest queued run follows.

Relates to #12.