### PR TITLE
chore(ci): eslint cli migration, node_modules cache, scheduled npm audit

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,0 +1,28 @@
+name: Audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    # monday 07:00 utc, catches advisories published while the repo is idle
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: jamesduxbury
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # audits the lockfile against the registry; no install needed. High or critical fail.
+      - name: npm audit
+        run: npm audit --audit-level=high

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,15 @@ jobs:
           cache: 'npm'
           cache-dependency-path: jamesduxbury/package-lock.json
 
+      - name: Cache node_modules
+        id: modules-cache
+        uses: actions/cache@v4
+        with:
+          path: jamesduxbury/node_modules
+          key: ${{ runner.os }}-node20-modules-${{ hashFiles('jamesduxbury/package-lock.json') }}
+
       - name: Install dependencies
+        if: steps.modules-cache.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Format check
@@ -70,7 +78,15 @@ jobs:
           cache: 'npm'
           cache-dependency-path: jamesduxbury/package-lock.json
 
+      - name: Cache node_modules
+        id: modules-cache
+        uses: actions/cache@v4
+        with:
+          path: jamesduxbury/node_modules
+          key: ${{ runner.os }}-node20-modules-${{ hashFiles('jamesduxbury/package-lock.json') }}
+
       - name: Install dependencies
+        if: steps.modules-cache.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Migrate and seed production

--- a/jamesduxbury/eslint.config.mjs
+++ b/jamesduxbury/eslint.config.mjs
@@ -10,6 +10,7 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
+  { ignores: [".next/**", "coverage/**", "next-env.d.ts"] },
   ...compat.extends("next/core-web-vitals", "next/typescript"),
 ];
 

--- a/jamesduxbury/package.json
+++ b/jamesduxbury/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "tsx src/db/migrate.ts && next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,css,json,md}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,css,json,md}\"",


### PR DESCRIPTION
CI overhaul in three commits.

- Migrates `next lint` (deprecated in Next 15) to the ESLint CLI. The existing flat config gains ignores for build artifacts; lint now also covers `tests/` and `scripts/`, both clean.
- Caches `node_modules` keyed on the lockfile in both ci.yaml jobs, skipping `npm ci` on a hit.
- Adds a separate audit workflow: runs on pushes, PRs, a weekly Monday schedule, and manual dispatch. It audits the lockfile without installing, prints the full report, and fails only on high or critical findings. Kept out of ci.yaml so scheduled runs never touch the dev database.

The five current moderate findings (the postcss chain via next's pinned 8.4.31, and brace-expansion in dev dependencies) are documented and will be removed in a follow-up dependency patch PR before the v3 release.

Closes #12