### PR TITLE
chore(deps): remove all moderate npm audit vulnerabilities

### DIFF
--- a/jamesduxbury/package-lock.json
+++ b/jamesduxbury/package-lock.json
@@ -34,7 +34,7 @@
         "eslint": "^9",
         "eslint-config-next": "^15.5.18",
         "jsdom": "^29.1.1",
-        "postcss": "^8.4.31",
+        "postcss": "^8.5.10",
         "postcss-import": "^16.1.0",
         "prettier": "^3.8.3",
         "prettier-plugin-tailwindcss": "^0.6.14",
@@ -3105,10 +3105,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -6154,33 +6155,6 @@
         "nodemailer": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-releases": {

--- a/jamesduxbury/package.json
+++ b/jamesduxbury/package.json
@@ -33,7 +33,8 @@
   "overrides": {
     "next-auth": {
       "nodemailer": "$nodemailer"
-    }
+    },
+    "postcss": "$postcss"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -49,7 +50,7 @@
     "eslint": "^9",
     "eslint-config-next": "^15.5.18",
     "jsdom": "^29.1.1",
-    "postcss": "^8.4.31",
+    "postcss": "^8.5.10",
     "postcss-import": "^16.1.0",
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.6.14",


### PR DESCRIPTION
Removes the five moderate vulnerabilities reported by `npm audit`.

- brace-expansion (GHSA-v6h2-p8h4-qcjw): bumped to 1.1.15 via `npm audit fix`.
- postcss (GHSA-qx2v-qp2m-jg93): next 15.5.18 pins postcss 8.4.31 internally, accounting for the other four findings (next, geist and next-auth flagged transitively). A next upgrade does not resolve it (latest stable still pins 8.4.31), so a package.json override forces postcss to the patched line. The devDependency carries the `^8.5.10` floor and the override references it with `$postcss`, matching the existing nodemailer override pattern.

`npm audit` now reports 0 vulnerabilities. Full validation gate run locally: format, typecheck, lint, 165 tests passing with coverage over thresholds, production build.

Closes #29