### PR TITLE
feat(loading): skeleton loading states for all public routes

### DIFF
--- a/jamesduxbury/src/app/about/loading.tsx
+++ b/jamesduxbury/src/app/about/loading.tsx
@@ -1,0 +1,19 @@
+import { SkeletonBits, SkeletonCursor } from '@/components/skeleton/Skeleton';
+import { SkeletonShell } from '@/components/skeleton/SkeletonShell';
+
+const LINES = [72, 64, 68, 44];
+
+export default function AboutLoading() {
+  return (
+    <SkeletonShell channel="01" label="ABOUT" ariaLabel="Loading about" widthClass="max-w-4xl">
+      <div className="space-y-4 px-4 py-6 sm:px-6">
+        {LINES.map((length, i) => (
+          <p key={i} className="overflow-hidden whitespace-nowrap">
+            <SkeletonBits length={length} className="text-sm" />
+            {i === LINES.length - 1 && <SkeletonCursor />}
+          </p>
+        ))}
+      </div>
+    </SkeletonShell>
+  );
+}

--- a/jamesduxbury/src/app/about/loading.tsx
+++ b/jamesduxbury/src/app/about/loading.tsx
@@ -1,4 +1,4 @@
-import { SkeletonBits, SkeletonCursor } from '@/components/skeleton/Skeleton';
+import { SkeletonLine } from '@/components/skeleton/Skeleton';
 import { SkeletonShell } from '@/components/skeleton/SkeletonShell';
 
 const LINES = [72, 64, 68, 44];
@@ -8,10 +8,12 @@ export default function AboutLoading() {
     <SkeletonShell channel="01" label="ABOUT" ariaLabel="Loading about" widthClass="max-w-4xl">
       <div className="space-y-4 px-4 py-6 sm:px-6">
         {LINES.map((length, i) => (
-          <p key={i} className="overflow-hidden whitespace-nowrap">
-            <SkeletonBits length={length} className="text-sm" />
-            {i === LINES.length - 1 && <SkeletonCursor />}
-          </p>
+          <SkeletonLine
+            key={i}
+            length={length}
+            textClassName="text-sm"
+            cursor={i === LINES.length - 1}
+          />
         ))}
       </div>
     </SkeletonShell>

--- a/jamesduxbury/src/app/about/page.tsx
+++ b/jamesduxbury/src/app/about/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
+import { PageShell } from '@/components/PageShell';
 import { AboutDetail } from '@/components/about/AboutDetail';
-import { Footer } from '@/components/Footer';
 
 export const metadata: Metadata = {
   title: 'About · James Duxbury',
@@ -13,17 +12,8 @@ export const revalidate = 60;
 
 export default function AboutPage() {
   return (
-    <>
-      <main className="mx-auto max-w-4xl px-4 pb-10 pt-28 sm:px-6 sm:pt-32">
-        <Link
-          href="/"
-          className="mb-8 inline-block font-mono text-xs uppercase tracking-[0.2em] text-muted transition-colors hover:text-accent"
-        >
-          ← / home
-        </Link>
-        <AboutDetail />
-      </main>
-      <Footer />
-    </>
+    <PageShell widthClass="max-w-4xl">
+      <AboutDetail />
+    </PageShell>
   );
 }

--- a/jamesduxbury/src/app/contact/loading.tsx
+++ b/jamesduxbury/src/app/contact/loading.tsx
@@ -1,0 +1,50 @@
+import { SkeletonBits, SkeletonCursor } from '@/components/skeleton/Skeleton';
+import { SkeletonShell } from '@/components/skeleton/SkeletonShell';
+
+function ChannelRowSkeleton() {
+  return (
+    <div className="grid grid-cols-1 gap-1 px-4 py-3.5 sm:grid-cols-[8rem_1fr_auto] sm:items-baseline sm:gap-6 sm:px-6 sm:py-4">
+      <SkeletonBits length={6} className="text-xs" />
+      <SkeletonBits length={20} className="text-xs" />
+      <SkeletonBits length={7} className="text-xs" />
+    </div>
+  );
+}
+
+function FieldSkeleton({ inputLength }: { inputLength: number }) {
+  return (
+    <div className="px-4 py-5 sm:px-6">
+      <SkeletonBits length={7} className="text-[0.65rem] sm:text-xs" />
+      <div className="mt-2 w-full overflow-hidden whitespace-nowrap border border-border bg-bg px-3 py-2.5">
+        <SkeletonBits length={inputLength} className="text-sm" />
+      </div>
+    </div>
+  );
+}
+
+export default function ContactLoading() {
+  return (
+    <SkeletonShell channel="06" label="CONTACT" ariaLabel="Loading contact" widthClass="max-w-4xl">
+      <div className="px-4 py-5 sm:px-6">
+        <SkeletonBits length={15} className="text-xs" />
+      </div>
+      <div className="divide-y divide-border border-y border-border">
+        <ChannelRowSkeleton />
+        <ChannelRowSkeleton />
+        <ChannelRowSkeleton />
+      </div>
+      <div className="px-4 py-5 sm:px-6">
+        <SkeletonBits length={26} className="text-xs" />
+      </div>
+      <div className="divide-y divide-border border-t border-border">
+        <FieldSkeleton inputLength={18} />
+        <FieldSkeleton inputLength={24} />
+        <FieldSkeleton inputLength={40} />
+        <div className="px-4 py-5 sm:px-6">
+          <SkeletonBits length={10} className="text-sm" />
+          <SkeletonCursor />
+        </div>
+      </div>
+    </SkeletonShell>
+  );
+}

--- a/jamesduxbury/src/app/contact/page.tsx
+++ b/jamesduxbury/src/app/contact/page.tsx
@@ -1,9 +1,8 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
+import { PageShell } from '@/components/PageShell';
 import { Widget } from '@/components/console/Widget';
 import { ContactForm } from '@/components/contact/ContactForm';
 import { ContactChannels } from '@/components/contact/ContactChannels';
-import { Footer } from '@/components/Footer';
 
 export const metadata: Metadata = {
   title: 'Contact · James Duxbury',
@@ -13,31 +12,21 @@ export const metadata: Metadata = {
 
 export default function ContactPage() {
   return (
-    <>
-      <main className="mx-auto max-w-4xl px-4 pb-10 pt-28 sm:px-6 sm:pt-32">
-        <Link
-          href="/"
-          className="mb-8 inline-block font-mono text-xs uppercase tracking-[0.2em] text-muted transition-colors hover:text-accent"
-        >
-          ← / home
-        </Link>
-
-        <Widget channel="06" label="CONTACT" id="contact">
-          <div className="px-4 py-5 sm:px-6">
-            <p className="font-mono text-xs uppercase tracking-[0.18em] text-muted">
-              {`>`} open channels
-            </p>
-          </div>
-          <ContactChannels />
-          <div className="px-4 py-5 sm:px-6">
-            <p className="font-mono text-xs uppercase tracking-[0.18em] text-muted">
-              {`>`} or send a message directly
-            </p>
-          </div>
-          <ContactForm />
-        </Widget>
-      </main>
-      <Footer />
-    </>
+    <PageShell widthClass="max-w-4xl">
+      <Widget channel="06" label="CONTACT" id="contact">
+        <div className="px-4 py-5 sm:px-6">
+          <p className="font-mono text-xs uppercase tracking-[0.18em] text-muted">
+            {`>`} open channels
+          </p>
+        </div>
+        <ContactChannels />
+        <div className="px-4 py-5 sm:px-6">
+          <p className="font-mono text-xs uppercase tracking-[0.18em] text-muted">
+            {`>`} or send a message directly
+          </p>
+        </div>
+        <ContactForm />
+      </Widget>
+    </PageShell>
   );
 }

--- a/jamesduxbury/src/app/education/loading.tsx
+++ b/jamesduxbury/src/app/education/loading.tsx
@@ -1,4 +1,4 @@
-import { SkeletonBits } from '@/components/skeleton/Skeleton';
+import { SkeletonBits, SkeletonLine } from '@/components/skeleton/Skeleton';
 import { SkeletonCollapsibleRow } from '@/components/skeleton/SkeletonCollapsibleRow';
 import { SkeletonShell } from '@/components/skeleton/SkeletonShell';
 
@@ -12,12 +12,8 @@ function CertificationCardSkeleton() {
         <SkeletonBits length={2} className="text-xs" />
       </span>
       <div className="flex-1 space-y-1">
-        <p className="overflow-hidden whitespace-nowrap">
-          <SkeletonBits length={24} className="text-sm" />
-        </p>
-        <p className="overflow-hidden whitespace-nowrap">
-          <SkeletonBits length={4} className="text-xs" />
-        </p>
+        <SkeletonLine length={24} textClassName="text-sm" />
+        <SkeletonLine length={4} textClassName="text-xs" />
       </div>
     </div>
   );

--- a/jamesduxbury/src/app/education/loading.tsx
+++ b/jamesduxbury/src/app/education/loading.tsx
@@ -1,0 +1,45 @@
+import { SkeletonBits } from '@/components/skeleton/Skeleton';
+import { SkeletonCollapsibleRow } from '@/components/skeleton/SkeletonCollapsibleRow';
+import { SkeletonShell } from '@/components/skeleton/SkeletonShell';
+
+function CertificationCardSkeleton() {
+  return (
+    <div className="flex items-center gap-3 border border-border bg-bg/40 p-3">
+      <span
+        aria-hidden
+        className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-sm border border-border bg-surface"
+      >
+        <SkeletonBits length={2} className="text-xs" />
+      </span>
+      <div className="flex-1 space-y-1">
+        <p className="overflow-hidden whitespace-nowrap">
+          <SkeletonBits length={24} className="text-sm" />
+        </p>
+        <p className="overflow-hidden whitespace-nowrap">
+          <SkeletonBits length={4} className="text-xs" />
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function EducationLoading() {
+  return (
+    <SkeletonShell
+      channel="05"
+      label="EDUCATION"
+      ariaLabel="Loading education"
+      widthClass="max-w-5xl"
+    >
+      <SkeletonCollapsibleRow />
+      <SkeletonCollapsibleRow />
+      <div className="border-t border-border px-4 py-5 sm:px-6">
+        <SkeletonBits length={28} className="text-xs" />
+        <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+          <CertificationCardSkeleton />
+          <CertificationCardSkeleton />
+        </div>
+      </div>
+    </SkeletonShell>
+  );
+}

--- a/jamesduxbury/src/app/education/page.tsx
+++ b/jamesduxbury/src/app/education/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
+import { PageShell } from '@/components/PageShell';
 import { EducationDetail } from '@/components/education/EducationDetail';
-import { Footer } from '@/components/Footer';
 
 export const metadata: Metadata = {
   title: 'Education · James Duxbury',
@@ -13,17 +12,8 @@ export const revalidate = 60;
 
 export default function EducationPage() {
   return (
-    <>
-      <main className="mx-auto max-w-5xl px-4 pb-10 pt-28 sm:px-6 sm:pt-32">
-        <Link
-          href="/"
-          className="mb-8 inline-block font-mono text-xs uppercase tracking-[0.2em] text-muted transition-colors hover:text-accent"
-        >
-          ← / home
-        </Link>
-        <EducationDetail />
-      </main>
-      <Footer />
-    </>
+    <PageShell widthClass="max-w-5xl">
+      <EducationDetail />
+    </PageShell>
   );
 }

--- a/jamesduxbury/src/app/experience/loading.tsx
+++ b/jamesduxbury/src/app/experience/loading.tsx
@@ -1,0 +1,18 @@
+import { SkeletonCollapsibleRow } from '@/components/skeleton/SkeletonCollapsibleRow';
+import { SkeletonShell } from '@/components/skeleton/SkeletonShell';
+
+export default function ExperienceLoading() {
+  return (
+    <SkeletonShell
+      channel="04"
+      label="EXPERIENCE"
+      ariaLabel="Loading experience"
+      widthClass="max-w-5xl"
+    >
+      <SkeletonCollapsibleRow />
+      <SkeletonCollapsibleRow />
+      <SkeletonCollapsibleRow />
+      <SkeletonCollapsibleRow />
+    </SkeletonShell>
+  );
+}

--- a/jamesduxbury/src/app/experience/page.tsx
+++ b/jamesduxbury/src/app/experience/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
+import { PageShell } from '@/components/PageShell';
 import { ExperienceDetail } from '@/components/experience/ExperienceDetail';
-import { Footer } from '@/components/Footer';
 
 export const metadata: Metadata = {
   title: 'Experience · James Duxbury',
@@ -13,17 +12,8 @@ export const revalidate = 60;
 
 export default function ExperiencePage() {
   return (
-    <>
-      <main className="mx-auto max-w-5xl px-4 pb-10 pt-28 sm:px-6 sm:pt-32">
-        <Link
-          href="/"
-          className="mb-8 inline-block font-mono text-xs uppercase tracking-[0.2em] text-muted transition-colors hover:text-accent"
-        >
-          ← / home
-        </Link>
-        <ExperienceDetail />
-      </main>
-      <Footer />
-    </>
+    <PageShell widthClass="max-w-5xl">
+      <ExperienceDetail />
+    </PageShell>
   );
 }

--- a/jamesduxbury/src/app/globals.css
+++ b/jamesduxbury/src/app/globals.css
@@ -46,3 +46,26 @@ body {
     @apply h-1.5 w-1.5 rounded-full;
   }
 }
+
+/* ── Skeleton loading states ────────────────────────────────────────── */
+
+.skeleton-cursor {
+  /* step-end holds each opacity flat so the cursor blinks rather than fades */
+  animation: skeleton-cursor 1.1s step-end infinite;
+}
+
+@keyframes skeleton-cursor {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-cursor {
+    animation: none;
+  }
+}

--- a/jamesduxbury/src/app/skills/loading.tsx
+++ b/jamesduxbury/src/app/skills/loading.tsx
@@ -1,0 +1,32 @@
+import { SkeletonBits } from '@/components/skeleton/Skeleton';
+import { SkeletonShell } from '@/components/skeleton/SkeletonShell';
+
+const GROUPS = [
+  [8, 12, 6, 10, 9],
+  [10, 7, 11, 6, 8, 9],
+  [9, 6, 12, 8],
+];
+
+export default function SkillsLoading() {
+  return (
+    <SkeletonShell channel="03" label="SKILLS" ariaLabel="Loading skills" widthClass="max-w-5xl">
+      <div className="divide-y divide-border">
+        {GROUPS.map((chips, i) => (
+          <div key={i} className="px-4 py-5 sm:px-6">
+            <div className="flex items-baseline justify-between gap-3">
+              <SkeletonBits length={14} className="text-sm" />
+              <SkeletonBits length={7} className="text-xs" />
+            </div>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {chips.map((length, j) => (
+                <span key={j} className="skill-badge">
+                  <SkeletonBits length={length} />
+                </span>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </SkeletonShell>
+  );
+}

--- a/jamesduxbury/src/app/skills/page.tsx
+++ b/jamesduxbury/src/app/skills/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
+import { PageShell } from '@/components/PageShell';
 import { SkillsDetail } from '@/components/skills/SkillsDetail';
-import { Footer } from '@/components/Footer';
 
 export const metadata: Metadata = {
   title: 'Skills · James Duxbury',
@@ -13,17 +12,8 @@ export const revalidate = 60;
 
 export default function SkillsPage() {
   return (
-    <>
-      <main className="mx-auto max-w-5xl px-4 pb-10 pt-28 sm:px-6 sm:pt-32">
-        <Link
-          href="/"
-          className="mb-8 inline-block font-mono text-xs uppercase tracking-[0.2em] text-muted transition-colors hover:text-accent"
-        >
-          ← / home
-        </Link>
-        <SkillsDetail />
-      </main>
-      <Footer />
-    </>
+    <PageShell widthClass="max-w-5xl">
+      <SkillsDetail />
+    </PageShell>
   );
 }

--- a/jamesduxbury/src/app/work/loading.tsx
+++ b/jamesduxbury/src/app/work/loading.tsx
@@ -1,0 +1,12 @@
+import { SkeletonShell } from '@/components/skeleton/SkeletonShell';
+import { ProjectRowSkeleton } from '@/components/work/ProjectRowSkeleton';
+
+export default function WorkLoading() {
+  return (
+    <SkeletonShell channel="02" label="WORK" ariaLabel="Loading work" widthClass="max-w-7xl">
+      <ProjectRowSkeleton />
+      <ProjectRowSkeleton />
+      <ProjectRowSkeleton />
+    </SkeletonShell>
+  );
+}

--- a/jamesduxbury/src/app/work/loading.tsx
+++ b/jamesduxbury/src/app/work/loading.tsx
@@ -1,5 +1,5 @@
 import { SkeletonShell } from '@/components/skeleton/SkeletonShell';
-import { ProjectRowSkeleton } from '@/components/work/ProjectRowSkeleton';
+import { ProjectRowSkeleton } from '@/components/skeleton/ProjectRowSkeleton';
 
 export default function WorkLoading() {
   return (

--- a/jamesduxbury/src/app/work/page.tsx
+++ b/jamesduxbury/src/app/work/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
+import { PageShell } from '@/components/PageShell';
 import { WorkDetail } from '@/components/work/WorkDetail';
-import { Footer } from '@/components/Footer';
 
 export const metadata: Metadata = {
   title: 'Work · James Duxbury',
@@ -13,17 +12,8 @@ export const revalidate = 60;
 
 export default function WorkPage() {
   return (
-    <>
-      <main className="mx-auto max-w-7xl px-4 pb-10 pt-28 sm:px-6 sm:pt-32">
-        <Link
-          href="/"
-          className="mb-8 inline-block font-mono text-xs uppercase tracking-[0.2em] text-muted transition-colors hover:text-accent"
-        >
-          ← / home
-        </Link>
-        <WorkDetail />
-      </main>
-      <Footer />
-    </>
+    <PageShell widthClass="max-w-7xl">
+      <WorkDetail />
+    </PageShell>
   );
 }

--- a/jamesduxbury/src/components/PageShell.tsx
+++ b/jamesduxbury/src/components/PageShell.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+import { Footer } from '@/components/Footer';
+
+interface PageShellProps {
+  widthClass: string;
+  loadingLabel?: string;
+  children: React.ReactNode;
+}
+
+// page chrome shared by the six section pages and their loading skeletons
+export function PageShell({ widthClass, loadingLabel, children }: PageShellProps) {
+  return (
+    <>
+      <main
+        aria-busy={loadingLabel ? true : undefined}
+        aria-label={loadingLabel}
+        className={`mx-auto ${widthClass} px-4 pb-10 pt-28 sm:px-6 sm:pt-32`}
+      >
+        <Link
+          href="/"
+          className="mb-8 inline-block font-mono text-xs uppercase tracking-[0.2em] text-muted transition-colors hover:text-accent"
+        >
+          ← / home
+        </Link>
+        {children}
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/jamesduxbury/src/components/console/Widget.tsx
+++ b/jamesduxbury/src/components/console/Widget.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { motion, type Variants } from 'framer-motion';
-import { SectionHeader } from './SectionHeader';
+import { WidgetFrame } from './WidgetFrame';
 
 interface WidgetProps {
   channel: string;
@@ -33,7 +33,8 @@ export const Widget: React.FC<WidgetProps> = ({
     variants={revealVariants}
     className={`scroll-mt-24 ${className ?? ''}`}
   >
-    <SectionHeader channel={channel} label={label} count={count} />
-    <div className="border border-border bg-surface/40 backdrop-blur-sm">{children}</div>
+    <WidgetFrame channel={channel} label={label} count={count}>
+      {children}
+    </WidgetFrame>
   </motion.section>
 );

--- a/jamesduxbury/src/components/console/WidgetFrame.tsx
+++ b/jamesduxbury/src/components/console/WidgetFrame.tsx
@@ -1,0 +1,18 @@
+import { SectionHeader } from './SectionHeader';
+
+interface WidgetFrameProps {
+  channel: string;
+  label: string;
+  count?: string | number;
+  children: React.ReactNode;
+}
+
+// static widget frame shared by Widget and the loading skeletons so they cannot drift
+export function WidgetFrame({ channel, label, count, children }: WidgetFrameProps) {
+  return (
+    <>
+      <SectionHeader channel={channel} label={label} count={count} />
+      <div className="border border-border bg-surface/40 backdrop-blur-sm">{children}</div>
+    </>
+  );
+}

--- a/jamesduxbury/src/components/skeleton/ProjectRowSkeleton.tsx
+++ b/jamesduxbury/src/components/skeleton/ProjectRowSkeleton.tsx
@@ -1,4 +1,4 @@
-import { SkeletonBits, SkeletonCursor } from '@/components/skeleton/Skeleton';
+import { SkeletonBits, SkeletonLine } from './Skeleton';
 
 export function ProjectRowSkeleton() {
   return (
@@ -13,25 +13,13 @@ export function ProjectRowSkeleton() {
           </span>
         </header>
 
-        <p className="mt-2 overflow-hidden whitespace-nowrap">
-          <SkeletonBits length={32} className="text-sm" />
-        </p>
-
-        <p className="mt-3 overflow-hidden whitespace-nowrap">
-          <SkeletonBits length={26} className="text-xs" />
-        </p>
+        <SkeletonLine length={32} className="mt-2" textClassName="text-sm" />
+        <SkeletonLine length={26} className="mt-3" textClassName="text-xs" />
 
         <div className="mt-4 space-y-2">
-          <p className="overflow-hidden whitespace-nowrap">
-            <SkeletonBits length={64} className="text-sm" />
-          </p>
-          <p className="overflow-hidden whitespace-nowrap">
-            <SkeletonBits length={56} className="text-sm" />
-          </p>
-          <p className="overflow-hidden whitespace-nowrap">
-            <SkeletonBits length={40} className="text-sm" />
-            <SkeletonCursor />
-          </p>
+          <SkeletonLine length={64} textClassName="text-sm" />
+          <SkeletonLine length={56} textClassName="text-sm" />
+          <SkeletonLine length={40} textClassName="text-sm" cursor />
         </div>
       </div>
 

--- a/jamesduxbury/src/components/skeleton/Skeleton.tsx
+++ b/jamesduxbury/src/components/skeleton/Skeleton.tsx
@@ -1,10 +1,25 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useReducedMotion } from 'framer-motion';
 
 const GLYPHS = ['░', '▒'];
 const JITTER_MS = 220;
+
+// one shared ticker for every SkeletonBits so a page of placeholders costs one timer
+const listeners = new Set<() => void>();
+let ticker: ReturnType<typeof setInterval> | null = null;
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  ticker ??= setInterval(() => listeners.forEach((l) => l()), JITTER_MS);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0 && ticker) {
+      clearInterval(ticker);
+      ticker = null;
+    }
+  };
+}
 
 interface SkeletonBitsProps {
   length: number;
@@ -12,22 +27,20 @@ interface SkeletonBitsProps {
 }
 
 export function SkeletonBits({ length, className }: SkeletonBitsProps) {
-  const reduceMotion = useReducedMotion();
   // deterministic first paint so server and client render the same string
   const [bits, setBits] = useState(() => '░'.repeat(length));
 
   useEffect(() => {
-    if (reduceMotion) return;
-    const id = setInterval(() => {
+    if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) return;
+    return subscribe(() =>
       // each bit re-rolls on roughly half the ticks so the field never moves in lockstep
       setBits((prev) =>
         Array.from(prev, (glyph) =>
           Math.random() < 0.5 ? glyph : GLYPHS[Math.floor(Math.random() * GLYPHS.length)],
         ).join(''),
-      );
-    }, JITTER_MS);
-    return () => clearInterval(id);
-  }, [length, reduceMotion]);
+      ),
+    );
+  }, []);
 
   return (
     <span aria-hidden className={`select-none font-mono text-text/30 ${className ?? ''}`}>
@@ -41,5 +54,26 @@ export function SkeletonCursor() {
     <span aria-hidden className="skeleton-cursor select-none font-mono text-text/30">
       ▒
     </span>
+  );
+}
+
+interface SkeletonLineProps {
+  length: number;
+  className?: string;
+  textClassName?: string;
+  cursor?: boolean;
+}
+
+export function SkeletonLine({
+  length,
+  className,
+  textClassName,
+  cursor = false,
+}: SkeletonLineProps) {
+  return (
+    <p className={`overflow-hidden whitespace-nowrap ${className ?? ''}`}>
+      <SkeletonBits length={length} className={textClassName} />
+      {cursor && <SkeletonCursor />}
+    </p>
   );
 }

--- a/jamesduxbury/src/components/skeleton/Skeleton.tsx
+++ b/jamesduxbury/src/components/skeleton/Skeleton.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useReducedMotion } from 'framer-motion';
+
+const GLYPHS = ['░', '▒'];
+const JITTER_MS = 220;
+
+interface SkeletonBitsProps {
+  length: number;
+  className?: string;
+}
+
+export function SkeletonBits({ length, className }: SkeletonBitsProps) {
+  const reduceMotion = useReducedMotion();
+  // deterministic first paint so server and client render the same string
+  const [bits, setBits] = useState(() => '░'.repeat(length));
+
+  useEffect(() => {
+    if (reduceMotion) return;
+    const id = setInterval(() => {
+      // each bit re-rolls on roughly half the ticks so the field never moves in lockstep
+      setBits((prev) =>
+        Array.from(prev, (glyph) =>
+          Math.random() < 0.5 ? glyph : GLYPHS[Math.floor(Math.random() * GLYPHS.length)],
+        ).join(''),
+      );
+    }, JITTER_MS);
+    return () => clearInterval(id);
+  }, [length, reduceMotion]);
+
+  return (
+    <span aria-hidden className={`select-none font-mono text-text/30 ${className ?? ''}`}>
+      {bits}
+    </span>
+  );
+}
+
+export function SkeletonCursor() {
+  return (
+    <span aria-hidden className="skeleton-cursor select-none font-mono text-text/30">
+      ▒
+    </span>
+  );
+}

--- a/jamesduxbury/src/components/skeleton/SkeletonCollapsibleRow.tsx
+++ b/jamesduxbury/src/components/skeleton/SkeletonCollapsibleRow.tsx
@@ -1,0 +1,22 @@
+import { SkeletonBits } from './Skeleton';
+
+export function SkeletonCollapsibleRow() {
+  return (
+    <div className="border-b border-border last:border-b-0">
+      <div className="flex w-full items-center gap-3 px-4 py-3 sm:px-6">
+        <span aria-hidden className="font-mono text-xs text-muted">
+          ▸
+        </span>
+        <div className="flex-1 space-y-1">
+          <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+            <SkeletonBits length={22} className="text-sm sm:text-base" />
+            <SkeletonBits length={14} className="text-[0.65rem]" />
+          </div>
+          <p className="overflow-hidden whitespace-nowrap">
+            <SkeletonBits length={18} className="text-xs" />
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/jamesduxbury/src/components/skeleton/SkeletonCollapsibleRow.tsx
+++ b/jamesduxbury/src/components/skeleton/SkeletonCollapsibleRow.tsx
@@ -1,4 +1,4 @@
-import { SkeletonBits } from './Skeleton';
+import { SkeletonBits, SkeletonLine } from './Skeleton';
 
 export function SkeletonCollapsibleRow() {
   return (
@@ -12,9 +12,7 @@ export function SkeletonCollapsibleRow() {
             <SkeletonBits length={22} className="text-sm sm:text-base" />
             <SkeletonBits length={14} className="text-[0.65rem]" />
           </div>
-          <p className="overflow-hidden whitespace-nowrap">
-            <SkeletonBits length={18} className="text-xs" />
-          </p>
+          <SkeletonLine length={18} textClassName="text-xs" />
         </div>
       </div>
     </div>

--- a/jamesduxbury/src/components/skeleton/SkeletonShell.tsx
+++ b/jamesduxbury/src/components/skeleton/SkeletonShell.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link';
+import { SectionHeader } from '@/components/console/SectionHeader';
+import { Footer } from '@/components/Footer';
+
+interface SkeletonShellProps {
+  channel: string;
+  label: string;
+  ariaLabel: string;
+  widthClass: string;
+  children: React.ReactNode;
+}
+
+export function SkeletonShell({
+  channel,
+  label,
+  ariaLabel,
+  widthClass,
+  children,
+}: SkeletonShellProps) {
+  return (
+    <>
+      <main
+        aria-busy="true"
+        aria-label={ariaLabel}
+        className={`mx-auto ${widthClass} px-4 pb-10 pt-28 sm:px-6 sm:pt-32`}
+      >
+        <Link
+          href="/"
+          className="mb-8 inline-block font-mono text-xs uppercase tracking-[0.2em] text-muted transition-colors hover:text-accent"
+        >
+          ← / home
+        </Link>
+        <section>
+          <SectionHeader channel={channel} label={label} />
+          <div className="border border-border bg-surface/40 backdrop-blur-sm">{children}</div>
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/jamesduxbury/src/components/skeleton/SkeletonShell.tsx
+++ b/jamesduxbury/src/components/skeleton/SkeletonShell.tsx
@@ -1,6 +1,5 @@
-import Link from 'next/link';
+import { PageShell } from '@/components/PageShell';
 import { WidgetFrame } from '@/components/console/WidgetFrame';
-import { Footer } from '@/components/Footer';
 
 interface SkeletonShellProps {
   channel: string;
@@ -18,25 +17,12 @@ export function SkeletonShell({
   children,
 }: SkeletonShellProps) {
   return (
-    <>
-      <main
-        aria-busy="true"
-        aria-label={ariaLabel}
-        className={`mx-auto ${widthClass} px-4 pb-10 pt-28 sm:px-6 sm:pt-32`}
-      >
-        <Link
-          href="/"
-          className="mb-8 inline-block font-mono text-xs uppercase tracking-[0.2em] text-muted transition-colors hover:text-accent"
-        >
-          ← / home
-        </Link>
-        <section>
-          <WidgetFrame channel={channel} label={label}>
-            {children}
-          </WidgetFrame>
-        </section>
-      </main>
-      <Footer />
-    </>
+    <PageShell widthClass={widthClass} loadingLabel={ariaLabel}>
+      <section>
+        <WidgetFrame channel={channel} label={label}>
+          {children}
+        </WidgetFrame>
+      </section>
+    </PageShell>
   );
 }

--- a/jamesduxbury/src/components/skeleton/SkeletonShell.tsx
+++ b/jamesduxbury/src/components/skeleton/SkeletonShell.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { SectionHeader } from '@/components/console/SectionHeader';
+import { WidgetFrame } from '@/components/console/WidgetFrame';
 import { Footer } from '@/components/Footer';
 
 interface SkeletonShellProps {
@@ -31,8 +31,9 @@ export function SkeletonShell({
           ← / home
         </Link>
         <section>
-          <SectionHeader channel={channel} label={label} />
-          <div className="border border-border bg-surface/40 backdrop-blur-sm">{children}</div>
+          <WidgetFrame channel={channel} label={label}>
+            {children}
+          </WidgetFrame>
         </section>
       </main>
       <Footer />

--- a/jamesduxbury/src/components/work/ProjectRowSkeleton.tsx
+++ b/jamesduxbury/src/components/work/ProjectRowSkeleton.tsx
@@ -1,0 +1,47 @@
+import { SkeletonBits, SkeletonCursor } from '@/components/skeleton/Skeleton';
+
+export function ProjectRowSkeleton() {
+  return (
+    <article className="border-b border-border last:border-b-0">
+      <div className="px-4 py-6 sm:px-6 sm:py-7">
+        <header className="flex flex-wrap items-baseline gap-x-4 gap-y-2">
+          <SkeletonBits length={3} className="text-xs" />
+          <SkeletonBits length={18} className="text-base sm:text-lg" />
+          <SkeletonBits length={11} className="text-xs" />
+          <span className="ml-auto">
+            <SkeletonBits length={7} className="text-xs" />
+          </span>
+        </header>
+
+        <p className="mt-2 overflow-hidden whitespace-nowrap">
+          <SkeletonBits length={32} className="text-sm" />
+        </p>
+
+        <p className="mt-3 overflow-hidden whitespace-nowrap">
+          <SkeletonBits length={26} className="text-xs" />
+        </p>
+
+        <div className="mt-4 space-y-2">
+          <p className="overflow-hidden whitespace-nowrap">
+            <SkeletonBits length={64} className="text-sm" />
+          </p>
+          <p className="overflow-hidden whitespace-nowrap">
+            <SkeletonBits length={56} className="text-sm" />
+          </p>
+          <p className="overflow-hidden whitespace-nowrap">
+            <SkeletonBits length={40} className="text-sm" />
+            <SkeletonCursor />
+          </p>
+        </div>
+      </div>
+
+      <div className="border-t border-border bg-bg/40 px-4 py-4 sm:px-6">
+        <SkeletonBits length={7} className="text-xs" />
+        <div className="mt-2 grid gap-2 sm:grid-cols-2">
+          <SkeletonBits length={28} className="text-xs" />
+          <SkeletonBits length={28} className="text-xs" />
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/jamesduxbury/tests/loading.dom.test.tsx
+++ b/jamesduxbury/tests/loading.dom.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import AboutLoading from '../src/app/about/loading';
+import ContactLoading from '../src/app/contact/loading';
+import EducationLoading from '../src/app/education/loading';
+import ExperienceLoading from '../src/app/experience/loading';
+import SkillsLoading from '../src/app/skills/loading';
+import WorkLoading from '../src/app/work/loading';
+
+const ROUTES = [
+  { name: 'about', Loading: AboutLoading, channel: '01', label: 'ABOUT' },
+  { name: 'work', Loading: WorkLoading, channel: '02', label: 'WORK' },
+  { name: 'skills', Loading: SkillsLoading, channel: '03', label: 'SKILLS' },
+  { name: 'experience', Loading: ExperienceLoading, channel: '04', label: 'EXPERIENCE' },
+  { name: 'education', Loading: EducationLoading, channel: '05', label: 'EDUCATION' },
+  { name: 'contact', Loading: ContactLoading, channel: '06', label: 'CONTACT' },
+];
+
+describe.each(ROUTES)('$name loading state', ({ name, Loading, channel, label }) => {
+  it('marks the page busy and labels it for assistive tech', () => {
+    render(<Loading />);
+    const main = screen.getByRole('main');
+    expect(main).toHaveAttribute('aria-busy', 'true');
+    expect(main).toHaveAttribute('aria-label', `Loading ${name}`);
+  });
+
+  it('mirrors the route shell', () => {
+    render(<Loading />);
+    expect(screen.getByText(label)).toBeInTheDocument();
+    expect(screen.getByText(`CHANNEL ${channel}`)).toBeInTheDocument();
+    expect(screen.getByText('← / home')).toBeInTheDocument();
+  });
+
+  it('keeps every placeholder out of the accessibility tree', () => {
+    const { container } = render(<Loading />);
+    container.querySelectorAll('span[class*="text-text/30"]').forEach((span) => {
+      expect(span).toHaveAttribute('aria-hidden', 'true');
+    });
+    // the bordered widget body must contain placeholder glyphs only, no real words
+    const body = container.querySelector('section > div.backdrop-blur-sm');
+    expect(body?.textContent).toMatch(/^[░▒▸\s]*$/);
+  });
+});
+
+describe('route-specific skeleton shapes', () => {
+  it('work renders three project-shaped rows', () => {
+    render(<WorkLoading />);
+    expect(screen.getAllByRole('article')).toHaveLength(3);
+  });
+
+  it('experience and education render collapsible-row placeholders', () => {
+    const exp = render(<ExperienceLoading />);
+    expect(exp.container.querySelectorAll('section > div > div').length).toBeGreaterThanOrEqual(4);
+    exp.unmount();
+
+    const edu = render(<EducationLoading />);
+    expect(edu.container.querySelector('.grid.grid-cols-1')).not.toBeNull();
+  });
+
+  it('skills renders chip-grid placeholders', () => {
+    const { container } = render(<SkillsLoading />);
+    expect(container.querySelectorAll('.skill-badge').length).toBeGreaterThan(10);
+  });
+
+  it('contact renders field placeholders without a submittable form', () => {
+    const { container } = render(<ContactLoading />);
+    expect(container.querySelector('form')).toBeNull();
+    expect(container.querySelectorAll('.border.border-border.bg-bg').length).toBe(3);
+  });
+});

--- a/jamesduxbury/tests/loading.dom.test.tsx
+++ b/jamesduxbury/tests/loading.dom.test.tsx
@@ -52,10 +52,11 @@ describe('route-specific skeleton shapes', () => {
 
   it('experience and education render collapsible-row placeholders', () => {
     const exp = render(<ExperienceLoading />);
-    expect(exp.container.querySelectorAll('section > div > div').length).toBeGreaterThanOrEqual(4);
+    expect(exp.getAllByText('▸')).toHaveLength(4);
     exp.unmount();
 
     const edu = render(<EducationLoading />);
+    expect(edu.getAllByText('▸')).toHaveLength(2);
     expect(edu.container.querySelector('.grid.grid-cols-1')).not.toBeNull();
   });
 

--- a/jamesduxbury/tests/setup.ts
+++ b/jamesduxbury/tests/setup.ts
@@ -7,6 +7,21 @@ loadEnvLocal();
 // jsdom looks like a browser to the driver; the warning does not apply to tests
 neonConfig.disableWarningInBrowsers = true;
 
+// jsdom lacks matchMedia, which the skeletons use for prefers-reduced-motion
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  window.matchMedia = (query: string): MediaQueryList =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList;
+}
+
 // jsdom lacks IntersectionObserver, which framer-motion's whileInView needs
 if (typeof window !== 'undefined' && !window.IntersectionObserver) {
   window.IntersectionObserver = class {

--- a/jamesduxbury/tests/skeleton.dom.test.tsx
+++ b/jamesduxbury/tests/skeleton.dom.test.tsx
@@ -2,18 +2,29 @@
 import { act, render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const reducedMotion = vi.fn(() => false);
-vi.mock('framer-motion', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('framer-motion')>();
-  return { ...actual, useReducedMotion: () => reducedMotion() };
-});
+import { SkeletonBits, SkeletonCursor, SkeletonLine } from '../src/components/skeleton/Skeleton';
 
-import { SkeletonBits, SkeletonCursor } from '../src/components/skeleton/Skeleton';
+function stubReducedMotion(matches: boolean) {
+  const original = window.matchMedia;
+  window.matchMedia = ((query: string) =>
+    ({
+      matches,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList) as typeof window.matchMedia;
+  return () => {
+    window.matchMedia = original;
+  };
+}
 
 describe('SkeletonBits', () => {
   afterEach(() => {
     vi.useRealTimers();
-    reducedMotion.mockReturnValue(false);
   });
 
   it('renders the requested number of block characters, hidden from the tree', () => {
@@ -41,8 +52,23 @@ describe('SkeletonBits', () => {
     expect(after).not.toBe(before);
   });
 
+  it('shares one ticker across instances', () => {
+    vi.useFakeTimers();
+    const spy = vi.spyOn(globalThis, 'setInterval');
+    const { unmount } = render(
+      <>
+        <SkeletonBits length={8} />
+        <SkeletonBits length={8} />
+        <SkeletonBits length={8} />
+      </>,
+    );
+    expect(spy).toHaveBeenCalledTimes(1);
+    unmount();
+    spy.mockRestore();
+  });
+
   it('does not animate when the user prefers reduced motion', () => {
-    reducedMotion.mockReturnValue(true);
+    const restore = stubReducedMotion(true);
     vi.useFakeTimers();
 
     const { container } = render(<SkeletonBits length={16} />);
@@ -53,6 +79,7 @@ describe('SkeletonBits', () => {
     });
 
     expect(container.querySelector('span')?.textContent).toBe(before);
+    restore();
   });
 });
 
@@ -63,5 +90,15 @@ describe('SkeletonCursor', () => {
     expect(span).toHaveAttribute('aria-hidden', 'true');
     expect(span).toHaveClass('skeleton-cursor');
     expect(span?.textContent?.trim()).toBe('▒');
+  });
+});
+
+describe('SkeletonLine', () => {
+  it('renders a clipped line of bits with an optional cursor', () => {
+    const { container } = render(<SkeletonLine length={20} cursor />);
+    const line = container.querySelector('p');
+    expect(line).toHaveClass('overflow-hidden', 'whitespace-nowrap');
+    expect(line?.querySelector('.skeleton-cursor')).not.toBeNull();
+    expect(line?.textContent?.replace(/\s/g, '')).toHaveLength(21);
   });
 });

--- a/jamesduxbury/tests/skeleton.dom.test.tsx
+++ b/jamesduxbury/tests/skeleton.dom.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { act, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const reducedMotion = vi.fn(() => false);
+vi.mock('framer-motion', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('framer-motion')>();
+  return { ...actual, useReducedMotion: () => reducedMotion() };
+});
+
+import { SkeletonBits, SkeletonCursor } from '../src/components/skeleton/Skeleton';
+
+describe('SkeletonBits', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    reducedMotion.mockReturnValue(false);
+  });
+
+  it('renders the requested number of block characters, hidden from the tree', () => {
+    const { container } = render(<SkeletonBits length={12} />);
+    const span = container.querySelector('span');
+    expect(span).toHaveAttribute('aria-hidden', 'true');
+    expect(span?.textContent).toHaveLength(12);
+    expect(span?.textContent).toMatch(/^[░▒]+$/);
+  });
+
+  it('re-rolls characters over time but only ever uses block glyphs', () => {
+    vi.useFakeTimers();
+    const { container } = render(<SkeletonBits length={24} />);
+    const span = container.querySelector('span');
+    const before = span?.textContent;
+
+    act(() => {
+      vi.advanceTimersByTime(220 * 6);
+    });
+
+    const after = span?.textContent;
+    expect(after).toHaveLength(24);
+    expect(after).toMatch(/^[░▒]+$/);
+    // 24 bits over 6 ticks: the odds of zero re-rolls are negligible
+    expect(after).not.toBe(before);
+  });
+
+  it('does not animate when the user prefers reduced motion', () => {
+    reducedMotion.mockReturnValue(true);
+    vi.useFakeTimers();
+
+    const { container } = render(<SkeletonBits length={16} />);
+    const before = container.querySelector('span')?.textContent;
+
+    act(() => {
+      vi.advanceTimersByTime(220 * 10);
+    });
+
+    expect(container.querySelector('span')?.textContent).toBe(before);
+  });
+});
+
+describe('SkeletonCursor', () => {
+  it('renders an aria-hidden blinking block with the cursor animation class', () => {
+    const { container } = render(<SkeletonCursor />);
+    const span = container.querySelector('span');
+    expect(span).toHaveAttribute('aria-hidden', 'true');
+    expect(span).toHaveClass('skeleton-cursor');
+    expect(span?.textContent?.trim()).toBe('▒');
+  });
+});


### PR DESCRIPTION
Adds loading skeletons to the six public routes.

Shared primitives in `src/components/skeleton/` render block glyphs that re-roll out of sync, with a blinking cursor. Animation is disabled under `prefers-reduced-motion`. Each route's `loading.tsx` mirrors its page shape so the swap to real content is quiet.

Closes #5
Closes #6