### PR TITLE
feat(images): admin image upload and Vercel Blob storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .env.local
+.vercel

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The site started as a static portfolio and is now a full-stack application. All 
 - Next.js 15 (App Router) with TypeScript and Tailwind CSS
 - Neon Postgres accessed with raw SQL, no ORM
 - Admin console behind GitHub OAuth, restricted to my account only
+- Site images stored in Vercel Blob, uploaded and replaced from the admin console
 - Public pages are statically cached (ISR) and revalidate instantly when I save an edit
 - First-party, privacy-light visit analytics with an admin dashboard
 - Deployed on Vercel; database migrations run on every build
@@ -46,6 +47,7 @@ flowchart TB
 
     github[GitHub OAuth]
     email[Email]
+    blob[(Vercel Blob)]
 
     pages --> isr
     isr -- raw SQL reads --> content
@@ -57,6 +59,8 @@ flowchart TB
     admin --> actions
     actions -- raw SQL writes --> content
     actions -- revalidatePath --> isr
+    actions -- image upload, delete --> blob
+    pages -- images --> blob
 
     push --> ci
     ci -- tests, Neon dev branch --> neon
@@ -71,7 +75,7 @@ flowchart TB
     classDef ops fill:#ffe4e6,stroke:#f43f5e,color:#881337
     class pages,beacon,form client
     class isr,visit,contact,admin,actions,auth app
-    class content,views,messages db
+    class content,views,messages,blob db
     class github,email ext
     class push,ci,deploy ops
     style browser fill:none,stroke:#3b82f6
@@ -91,6 +95,10 @@ Sign-in is GitHub OAuth through next-auth v5 with JWT sessions and no database a
 ### Admin console
 
 Each content section is defined once in a registry (`src/admin/sections.ts`) as field config plus a Zod schema. The list, create, edit and delete pages, the form rendering, and the SQL are all generic, so adding a section is configuration rather than new code. The console also has a messages inbox and the analytics dashboard.
+
+### Images
+
+Site images (the profile picture, certification badges, project images) live in Vercel Blob and are served from its CDN. The admin form kit has an upload field type: saving uploads the file, writes its URL to the row, and deletes the blob it replaced; deleting a row deletes its blobs, so the store never accumulates unused files. Each environment uploads its own copies, which keeps a replacement in one environment from breaking the other.
 
 ### Analytics
 
@@ -126,7 +134,7 @@ The admin console:
 
 ### No ORM
 
-The schema is eight tables and the queries are straightforward. The Neon driver parameterises every tagged-template value, so the usual injection argument for an ORM does not apply, and the whole data layer stays readable in two files. Working directly with SQL was also part of the point of the project.
+The schema is nine tables and the queries are straightforward. The Neon driver parameterises every tagged-template value, so the usual injection argument for an ORM does not apply, and the whole data layer stays readable in two files. Working directly with SQL was also part of the point of the project.
 
 ### A single-user allowlist instead of roles
 
@@ -144,6 +152,10 @@ Visitors get statically cached pages; the database is not touched per request. S
 
 I want rough visit numbers, not a tracking product. Collecting a per-tab session id and no cookies, IPs or fingerprints keeps the data in my own database and keeps the site free of consent banners.
 
+### Images in Vercel Blob
+
+The images are a few megabytes in total, so almost anything would work. I evaluated Cloudflare R2 and Postgres bytea behind a cached route handler; Blob won because it needs no extra account or dependency and serves straight from the CDN with no route handler in the path. Old blobs are deleted when an image is replaced, so quota stays flat.
+
 ### No chart library
 
 The dashboard chart is a server-rendered bar chart built from divs. It is one dependency fewer and renders without client-side JavaScript.
@@ -153,6 +165,7 @@ The dashboard chart is a server-rendered bar chart built from divs. It is one de
 | Table | Contents |
 |---|---|
 | `projects`, `experience`, `education`, `certifications`, `skill_groups`, `about_paragraphs` | Site content, one table per section, ordered by an integer `sort_order` |
+| `site_settings` | Single row of site-wide settings (currently the profile picture) |
 | `messages` | Contact form submissions |
 | `page_views` | Analytics events |
 
@@ -181,6 +194,7 @@ DATABASE_URL=postgres://...        # Neon dev branch
 GITHUB_ID=...                      # localhost OAuth app
 GITHUB_SECRET=...
 AUTH_SECRET=...                    # npx auth secret, or openssl rand -base64 32
+BLOB_READ_WRITE_TOKEN=...          # Vercel Blob store with public access
 ```
 
 Then set up the database and run:
@@ -204,6 +218,7 @@ npm run dev
 | `npm run db:migrate` | Apply pending migrations |
 | `npm run db:push` | Apply `schema.sql` to a fresh database |
 | `npm run db:seed` | Insert-if-missing seed from `src/data/*.ts` |
+| `npm run images:migrate` | One-off upload of static `/images` rows to Vercel Blob |
 
 ## Testing
 

--- a/jamesduxbury/.env.example
+++ b/jamesduxbury/.env.example
@@ -7,3 +7,6 @@ GITHUB_ID=your-oauth-app-client-id
 GITHUB_SECRET=your-oauth-app-client-secret
 # Generate with: openssl rand -base64 32
 AUTH_SECRET=random-32-byte-secret
+
+# Vercel Blob token for admin image uploads 
+BLOB_READ_WRITE_TOKEN=vercel_blob_rw_xxxxxxxxxxxx

--- a/jamesduxbury/next.config.ts
+++ b/jamesduxbury/next.config.ts
@@ -3,6 +3,13 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   trailingSlash: false,
+  images: {
+    remotePatterns: [{ protocol: "https", hostname: "*.public.blob.vercel-storage.com" }],
+  },
+  experimental: {
+    // default 1mb is too small for image uploads; Vercel functions cap bodies at 4.5mb
+    serverActions: { bodySizeLimit: "4mb" },
+  },
 };
 
 export default nextConfig;

--- a/jamesduxbury/next.config.ts
+++ b/jamesduxbury/next.config.ts
@@ -7,8 +7,8 @@ const nextConfig: NextConfig = {
     remotePatterns: [{ protocol: "https", hostname: "*.public.blob.vercel-storage.com" }],
   },
   experimental: {
-    // default 1mb is too small for image uploads; Vercel functions cap bodies at 4.5mb
-    serverActions: { bodySizeLimit: "4mb" },
+    // headroom over the 4mb image cap for multipart overhead; 4.5mb is the Vercel function limit
+    serverActions: { bodySizeLimit: "4.5mb" },
   },
 };
 

--- a/jamesduxbury/package-lock.json
+++ b/jamesduxbury/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@neondatabase/serverless": "^1.1.0",
+        "@vercel/blob": "^2.4.0",
         "autoprefixer": "^10.4.20",
         "framer-motion": "^12.38.0",
         "geist": "^1.7.0",
@@ -2565,6 +2566,31 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.4.0.tgz",
+      "integrity": "sha512-ncQ8CRb6XoEAYJwjOTRGpACRT6h/AeY+/33gLyeVxG5BIes27OPm1jmqreF+JHjcTmGhClTP+kBpmyLfbV0xew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vercel/blob/node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
@@ -3005,6 +3031,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/autoprefixer": {
@@ -5008,6 +5043,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-bun-module": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-1.3.0.tgz",
@@ -5151,6 +5209,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -7033,6 +7097,15 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -7855,6 +7928,18 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tinybench": {

--- a/jamesduxbury/package.json
+++ b/jamesduxbury/package.json
@@ -14,6 +14,7 @@
     "db:migrate": "tsx src/db/migrate.ts",
     "db:push": "tsx src/db/migrate.ts --push",
     "db:seed": "tsx scripts/seed.ts",
+    "images:migrate": "tsx scripts/migrate-images.ts",
     "test": "vitest run --coverage",
     "test:watch": "vitest"
   },

--- a/jamesduxbury/package.json
+++ b/jamesduxbury/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.1.0",
+    "@vercel/blob": "^2.4.0",
     "autoprefixer": "^10.4.20",
     "framer-motion": "^12.38.0",
     "geist": "^1.7.0",

--- a/jamesduxbury/scripts/migrate-images.ts
+++ b/jamesduxbury/scripts/migrate-images.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { neon } from '@neondatabase/serverless';
+import { loadEnvLocal } from '../src/db/env';
+import { uploadImage } from '../src/admin/images';
+
+// uploads /images/* rows to the blob store, once per environment so envs never share blobs
+loadEnvLocal();
+const url = process.env.DATABASE_URL;
+if (!url || !process.env.BLOB_READ_WRITE_TOKEN) {
+  console.error('DATABASE_URL and BLOB_READ_WRITE_TOKEN must be set (env or .env.local).');
+  process.exit(1);
+}
+const sql = neon(url);
+const publicDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'public');
+
+const TARGETS = [
+  { table: 'site_settings', column: 'profile_image' },
+  { table: 'certifications', column: 'img_path' },
+  { table: 'projects', column: 'image_path' },
+] as const;
+
+function mimeType(path: string): string {
+  if (path.endsWith('.webp')) return 'image/webp';
+  if (path.endsWith('.jpg') || path.endsWith('.jpeg')) return 'image/jpeg';
+  return 'image/png';
+}
+
+async function main(): Promise<void> {
+  let failures = 0;
+  for (const { table, column } of TARGETS) {
+    const rows = (await sql.query(
+      `SELECT id, ${column} AS path FROM ${table} WHERE ${column} LIKE '/images/%'`,
+    )) as { id: number; path: string }[];
+    for (const row of rows) {
+      let buffer: Buffer;
+      try {
+        buffer = readFileSync(join(publicDir, row.path));
+      } catch {
+        console.error(`${table}.${column} #${row.id}: missing file public${row.path}`);
+        failures += 1;
+        continue;
+      }
+      const file = new File([buffer], basename(row.path), { type: mimeType(row.path) });
+      const blobUrl = await uploadImage(file);
+      await sql.query(`UPDATE ${table} SET ${column} = $1 WHERE id = $2`, [blobUrl, row.id]);
+      console.log(`${table}.${column} #${row.id}: ${row.path} -> ${blobUrl}`);
+    }
+  }
+  if (failures > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/jamesduxbury/src/admin/actions.ts
+++ b/jamesduxbury/src/admin/actions.ts
@@ -5,9 +5,10 @@ import { redirect } from 'next/navigation';
 import { auth, isAdminSession } from '@/auth';
 import { getSql } from '@/db';
 import { SITE_ROUTES } from '@/lib/site';
-import { parseFields, type FieldDef } from './fields';
+import { parseFields, type FieldDef, type FieldValue } from './fields';
+import { deleteImage, imageFileError, uploadImage } from './images';
 import { getSection } from './sections';
-import { deleteRow, insertRow, makeRoomAt, updateRow } from './sql';
+import { deleteRow, getRow, insertRow, makeRoomAt, updateRow } from './sql';
 
 export interface FormState {
   message: string | null;
@@ -16,6 +17,10 @@ export interface FormState {
 
 async function requireAdmin(): Promise<void> {
   if (!isAdminSession(await auth())) throw new Error('Unauthorised');
+}
+
+function imageFields(fields: FieldDef[]): FieldDef[] {
+  return fields.filter((f) => f.type === 'image');
 }
 
 function revalidatePublicPages(): void {
@@ -43,6 +48,22 @@ export async function saveItem(
   const section = getSection(slug);
 
   const values = parseFields(section.fields, formData);
+  const images = imageFields(section.fields);
+  const files = new Map<string, File>();
+  for (const f of images) {
+    const raw = formData.get(f.column);
+    if (raw instanceof File && raw.size > 0) {
+      const error = imageFileError(raw);
+      if (error) return { message: 'Validation failed', fieldErrors: { [f.column]: error } };
+      files.set(f.column, raw);
+    }
+  }
+  // an empty file input keeps the stored image
+  const prior = id !== null && images.length > 0 ? await getRow(section.table, id) : null;
+  for (const f of images) {
+    if (!files.has(f.column)) values[f.column] = (prior?.[f.column] as FieldValue) ?? null;
+  }
+
   const parsed = section.schema.safeParse(values);
   if (!parsed.success) {
     const fieldErrors: Record<string, string> = {};
@@ -53,15 +74,25 @@ export async function saveItem(
     return { message: 'Validation failed', fieldErrors };
   }
 
+  const uploaded: string[] = [];
   try {
     const row = toSqlValues(section.fields, parsed.data);
+    for (const [column, file] of files) {
+      const url = await uploadImage(file);
+      uploaded.push(url);
+      row[column] = url;
+    }
     const sortOrder = row.sort_order;
     if (typeof sortOrder === 'number') await makeRoomAt(section.table, sortOrder, id);
     if (id === null) await insertRow(section.table, row);
     else await updateRow(section.table, id, row);
   } catch (err) {
+    // a failed save must not leave blobs the row never referenced
+    for (const url of uploaded) await deleteImage(url);
     return { message: err instanceof Error ? err.message : 'Save failed', fieldErrors: {} };
   }
+
+  if (prior !== null) for (const column of files.keys()) await deleteImage(prior[column]);
 
   revalidatePublicPages();
   revalidatePath(`/admin/${slug}`);
@@ -71,7 +102,10 @@ export async function saveItem(
 export async function deleteItem(slug: string, id: number): Promise<void> {
   await requireAdmin();
   const section = getSection(slug);
+  const images = imageFields(section.fields);
+  const row = images.length > 0 ? await getRow(section.table, id) : null;
   await deleteRow(section.table, id);
+  for (const f of images) await deleteImage(row?.[f.column]);
   revalidatePublicPages();
   revalidatePath(`/admin/${slug}`);
 }

--- a/jamesduxbury/src/admin/fields.ts
+++ b/jamesduxbury/src/admin/fields.ts
@@ -13,7 +13,8 @@ export type FieldType =
   | 'select'
   | 'checkbox'
   | 'metrics'
-  | 'runs';
+  | 'runs'
+  | 'image';
 
 export interface FieldDef {
   column: string;
@@ -82,6 +83,10 @@ export function parseFields(fields: FieldDef[], formData: FormData): Record<stri
       }
       case 'runs':
         out[f.column] = parseRuns(text);
+        break;
+      // the file is uploaded in the action, which fills the column
+      case 'image':
+        out[f.column] = null;
         break;
     }
   }

--- a/jamesduxbury/src/admin/images.ts
+++ b/jamesduxbury/src/admin/images.ts
@@ -1,0 +1,34 @@
+import { del, put } from '@vercel/blob';
+
+const ALLOWED_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp']);
+// matches the serverActions bodySizeLimit in next.config.ts
+const MAX_BYTES = 4 * 1024 * 1024;
+
+export function imageFileError(file: File): string | null {
+  if (!ALLOWED_TYPES.has(file.type)) return 'Image must be png, jpeg or webp';
+  if (file.size > MAX_BYTES) return 'Image must be 4MB or smaller';
+  return null;
+}
+
+export function isBlobUrl(url: string): boolean {
+  try {
+    return new URL(url).hostname.endsWith('.public.blob.vercel-storage.com');
+  } catch {
+    return false;
+  }
+}
+
+export async function uploadImage(file: File): Promise<string> {
+  const { url } = await put(file.name, file, { access: 'public', addRandomSuffix: true });
+  return url;
+}
+
+// skips legacy /images paths so only store-owned blobs are ever deleted
+export async function deleteImage(url: unknown): Promise<void> {
+  if (typeof url !== 'string' || !isBlobUrl(url)) return;
+  try {
+    await del(url);
+  } catch {
+    // a failed delete only leaves an orphan; the row no longer references it
+  }
+}

--- a/jamesduxbury/src/admin/sections.ts
+++ b/jamesduxbury/src/admin/sections.ts
@@ -18,6 +18,13 @@ const optionalBullets = z
   .array(z.string().min(1))
   .transform((lines) => (lines.length ? lines : null));
 
+const imageField = (column: string): FieldDef => ({
+  column,
+  label: 'Image',
+  type: 'image',
+  help: 'png, jpeg or webp up to 4MB; empty keeps the current image',
+});
+
 const metricSchema = z.object({
   label: z.string().min(1),
   value: z.string().min(1),
@@ -56,7 +63,7 @@ export const SECTIONS: SectionConfig[] = [
         type: 'metrics',
         help: 'ratio is the 0–1 bar fill, optional — remove all rows for none',
       },
-      { column: 'image_path', label: 'Image path', type: 'text' },
+      imageField('image_path'),
       { column: 'github_link', label: 'GitHub link', type: 'url' },
       { column: 'live_link', label: 'Live link', type: 'url' },
       { column: 'sort_order', label: 'Sort order', type: 'sort_order' },
@@ -139,7 +146,7 @@ export const SECTIONS: SectionConfig[] = [
     fields: [
       { column: 'name', label: 'Name', type: 'text' },
       { column: 'year', label: 'Year', type: 'text', help: 'display text, e.g. 2024' },
-      { column: 'img_path', label: 'Image path', type: 'text' },
+      imageField('img_path'),
       { column: 'certification_link', label: 'Certification link', type: 'url' },
       { column: 'sort_order', label: 'Sort order', type: 'sort_order' },
     ],

--- a/jamesduxbury/src/admin/sections.ts
+++ b/jamesduxbury/src/admin/sections.ts
@@ -206,6 +206,16 @@ export const SECTIONS: SectionConfig[] = [
       return text.length > 80 ? `${text.slice(0, 80)}…` : text;
     },
   },
+  {
+    slug: 'site',
+    table: 'site_settings',
+    title: 'Site',
+    fields: [imageField('profile_image')],
+    schema: z.object({
+      profile_image: z.string().min(1).nullable(),
+    }),
+    listLabel: () => 'Site settings',
+  },
 ];
 
 export function getSection(slug: string): SectionConfig {

--- a/jamesduxbury/src/admin/sql.ts
+++ b/jamesduxbury/src/admin/sql.ts
@@ -38,10 +38,12 @@ export async function updateRow(
 ): Promise<void> {
   const cols = Object.keys(values);
   const sets = cols.map((c, i) => `${c} = $${i + 1}`);
-  await getSql().query(
-    `UPDATE ${table} SET ${sets.join(', ')}, updated_at = now() WHERE id = $${cols.length + 1}`,
+  const rows = (await getSql().query(
+    `UPDATE ${table} SET ${sets.join(', ')}, updated_at = now() WHERE id = $${cols.length + 1} RETURNING id`,
     [...cols.map((c) => values[c]), id],
-  );
+  )) as unknown[];
+  // surfaces a concurrent delete instead of silently updating nothing
+  if (rows.length === 0) throw new Error('Row no longer exists');
 }
 
 export async function deleteRow(table: string, id: number): Promise<void> {

--- a/jamesduxbury/src/app/page.tsx
+++ b/jamesduxbury/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { Entry } from '@/components/Entry';
+import { getSiteSettings } from '@/db/queries';
 import { AboutSummary } from '@/components/about/AboutSummary';
 import { WorkSummary } from '@/components/work/WorkSummary';
 import { SkillsSummary } from '@/components/skills/SkillsSummary';
@@ -8,10 +9,11 @@ import { Footer } from '@/components/Footer';
 
 export const revalidate = 60;
 
-export default function Home() {
+export default async function Home() {
+  const { profileImage } = await getSiteSettings();
   return (
     <>
-      <Entry />
+      <Entry profileImage={profileImage} />
       <main className="mx-auto max-w-7xl space-y-10 px-4 pt-12 sm:px-6">
         <AboutSummary />
 

--- a/jamesduxbury/src/components/Entry.tsx
+++ b/jamesduxbury/src/components/Entry.tsx
@@ -6,7 +6,7 @@ import { SectionHeader } from './console/SectionHeader';
 import { SpecRow } from './console/SpecRow';
 import { StatusChip } from './console/StatusChip';
 
-export const Entry: React.FC = () => {
+export const Entry: React.FC<{ profileImage: string }> = ({ profileImage }) => {
   return (
     <section id="entry" className="w-full pt-20 sm:pt-24">
       <div className="mx-auto max-w-7xl px-4 sm:px-6">
@@ -15,7 +15,7 @@ export const Entry: React.FC = () => {
         <div className="grid grid-cols-1 gap-8 sm:grid-cols-[auto_1fr] sm:items-start sm:gap-12">
           <div className="relative h-36 w-36 overflow-hidden border border-border sm:h-40 sm:w-40 lg:h-44 lg:w-44">
             <Image
-              src="/images/profile-picture.png"
+              src={profileImage}
               alt="James Duxbury"
               fill
               sizes="(max-width: 640px) 144px, 176px"

--- a/jamesduxbury/src/components/admin/SectionForm.tsx
+++ b/jamesduxbury/src/components/admin/SectionForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Image from 'next/image';
 import { useActionState, useState } from 'react';
 import type { FormState } from '@/admin/actions';
 import type { FieldDef, FieldDefault, MetricDraft } from '@/admin/fields';
@@ -188,6 +189,28 @@ function FieldInput({ field, defaultValue }: { field: FieldDef; defaultValue: Fi
           defaultValue={text}
           className={fieldInput}
         />
+      );
+    case 'image':
+      return (
+        <div className="mt-2">
+          {text && (
+            <Image
+              src={text}
+              alt="current image"
+              width={80}
+              height={80}
+              unoptimized
+              className="mb-3 border border-border object-cover"
+            />
+          )}
+          <input
+            id={field.column}
+            name={field.column}
+            type="file"
+            accept="image/png,image/jpeg,image/webp"
+            className={`${fieldInput} mt-0 cursor-pointer file:mr-4 file:cursor-pointer file:border-0 file:bg-transparent file:font-mono file:text-xs file:uppercase file:tracking-[0.18em] file:text-accent`}
+          />
+        </div>
       );
     case 'url':
       return (

--- a/jamesduxbury/src/data/certifications.ts
+++ b/jamesduxbury/src/data/certifications.ts
@@ -13,41 +13,47 @@ export const certifications: Certification[] = [
   {
     name: 'Microsoft Azure AI Fundamentals',
     year: '2024',
-    imgPath: '/images/certifications/microsoft-certified-azure-ai-fundamentals.png',
+    imgPath:
+      'https://aaobkpkc4uh9kgtn.public.blob.vercel-storage.com/microsoft-certified-azure-ai-fundamentals-oKCWGncdd3P2s0e3nNCjYFTnN6Na6y.png',
     certificationLink:
       'https://www.credly.com/badges/8839de8b-befc-4eb9-a76a-c0ba585209d5/public_url',
   },
   {
     name: 'ITIL 4 Foundation',
     year: '2021',
-    imgPath: '/images/certifications/itil-4-foundation.png',
+    imgPath:
+      'https://aaobkpkc4uh9kgtn.public.blob.vercel-storage.com/itil-4-foundation-36lcxcAApbTIwx7pkybi6q1O8w8lav.png',
     certificationLink: 'https://www.axelos.com/successful-candidates-register',
   },
   {
     name: 'IBM Enterprise Design Thinking Practitioner',
     year: '2023',
-    imgPath: '/images/certifications/enterprise-design-thinking-practitioner.png',
+    imgPath:
+      'https://aaobkpkc4uh9kgtn.public.blob.vercel-storage.com/enterprise-design-thinking-practitioner-965x4kzJCSkLSc4HuFsw42w6xIchix.png',
     certificationLink:
       'https://www.credly.com/badges/5ae35ca4-9988-47ae-adfe-2988903b2fba/public_url',
   },
   {
     name: 'IBM SkillsBuild: Enterprise Data Science in Practice',
     year: '2023',
-    imgPath: '/images/certifications/enterprise-data-science-in-practice.1.png',
+    imgPath:
+      'https://aaobkpkc4uh9kgtn.public.blob.vercel-storage.com/enterprise-data-science-in-practice.1-LQ1ggimJk0kzotabDD2oV8Q30dDoMs.png',
     certificationLink:
       'https://www.credly.com/badges/9d5c8f4d-78f6-4c92-a106-38c6df8dd8b1/public_url',
   },
   {
     name: 'IBM SkillsBuild: Getting Started with Enterprise Data Science',
     year: '2023',
-    imgPath: '/images/certifications/getting-started-with-enterprise-data-science.2.png',
+    imgPath:
+      'https://aaobkpkc4uh9kgtn.public.blob.vercel-storage.com/getting-started-with-enterprise-data-science.2-Rm9hv5pAhg2qutejQe84VdUEbp6qd0.png',
     certificationLink:
       'https://www.credly.com/badges/1de318f0-f1a6-40b3-aae0-f1d16471d0fd/public_url',
   },
   {
     name: 'IBM SkillsBuild: Journey to Cloud: Envisioning Your Solution',
     year: '2023',
-    imgPath: '/images/certifications/journey-to-cloud-envisioning-your-solution.2.png',
+    imgPath:
+      'https://aaobkpkc4uh9kgtn.public.blob.vercel-storage.com/journey-to-cloud-envisioning-your-solution.2-6Src6GQovtAyt8z4UVNGx0tN73DAyp.png',
     certificationLink:
       'https://www.credly.com/badges/c34f7fd2-ea25-4aa8-92a0-04501f341bbf/public_url',
   },

--- a/jamesduxbury/src/data/projects.ts
+++ b/jamesduxbury/src/data/projects.ts
@@ -89,7 +89,8 @@ export const projects: Project[] = [
       "Applied Canny edge detection to identify damaged regions and Criminisi's inpainting algorithm for realistic restoration.",
       'Coursework awarded a first-class grade.',
     ],
-    imagePath: '/images/projects/xray-image-repair.png',
+    imagePath:
+      'https://aaobkpkc4uh9kgtn.public.blob.vercel-storage.com/xray-image-repair-chKwesUpc9d6Xw6PJdjZHoW9cU99cr.png',
     githubLink: 'https://github.com/jsduxie/opencv-xray-repair',
   },
   {

--- a/jamesduxbury/src/data/site.ts
+++ b/jamesduxbury/src/data/site.ts
@@ -1,0 +1,8 @@
+export interface SiteSettings {
+  profileImage: string;
+}
+
+export const siteSettings: SiteSettings = {
+  profileImage:
+    'https://aaobkpkc4uh9kgtn.public.blob.vercel-storage.com/profile-picture-tW8qoosbaFQh1fT785F06lOYpLccJN.png',
+};

--- a/jamesduxbury/src/db/migrations/0002_site_settings.sql
+++ b/jamesduxbury/src/db/migrations/0002_site_settings.sql
@@ -1,0 +1,8 @@
+-- single settings row; sort_order only satisfies the generic admin list ordering
+CREATE TABLE IF NOT EXISTS site_settings (
+  id integer PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+  profile_image text NOT NULL,
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);

--- a/jamesduxbury/src/db/queries.ts
+++ b/jamesduxbury/src/db/queries.ts
@@ -5,6 +5,7 @@ import type { Degree } from '@/data/education';
 import type { Certification } from '@/data/certifications';
 import type { SkillGroup } from '@/data/skills';
 import type { AboutParagraph } from '@/data/about';
+import { siteSettings, type SiteSettings } from '@/data/site';
 
 interface ProjectRow {
   slug: string;
@@ -106,15 +107,11 @@ export async function getSkillGroups(): Promise<SkillGroup[]> {
   return rows.map((r) => ({ heading: r.heading, skills: r.skills }));
 }
 
-export interface SiteSettings {
-  profileImage: string;
-}
-
 export async function getSiteSettings(): Promise<SiteSettings> {
   const rows = (await getSql()`SELECT profile_image FROM site_settings WHERE id = 1`) as {
     profile_image: string;
   }[];
-  return { profileImage: rows[0]?.profile_image ?? '/images/profile-picture.png' };
+  return { profileImage: rows[0]?.profile_image ?? siteSettings.profileImage };
 }
 
 export async function getAboutParagraphs(): Promise<AboutParagraph[]> {

--- a/jamesduxbury/src/db/queries.ts
+++ b/jamesduxbury/src/db/queries.ts
@@ -106,6 +106,17 @@ export async function getSkillGroups(): Promise<SkillGroup[]> {
   return rows.map((r) => ({ heading: r.heading, skills: r.skills }));
 }
 
+export interface SiteSettings {
+  profileImage: string;
+}
+
+export async function getSiteSettings(): Promise<SiteSettings> {
+  const rows = (await getSql()`SELECT profile_image FROM site_settings WHERE id = 1`) as {
+    profile_image: string;
+  }[];
+  return { profileImage: rows[0]?.profile_image ?? '/images/profile-picture.png' };
+}
+
 export async function getAboutParagraphs(): Promise<AboutParagraph[]> {
   const rows = (await getSql()`SELECT runs FROM about_paragraphs ORDER BY sort_order`) as {
     runs: AboutParagraph;

--- a/jamesduxbury/src/db/schema.sql
+++ b/jamesduxbury/src/db/schema.sql
@@ -86,6 +86,15 @@ CREATE TABLE IF NOT EXISTS messages (
   created_at timestamptz NOT NULL DEFAULT now()
 );
 
+-- single settings row; sort_order only satisfies the generic admin list ordering
+CREATE TABLE IF NOT EXISTS site_settings (
+  id integer PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+  profile_image text NOT NULL,
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
 -- Deliberately no cookies, IPs, or fingerprinting
 CREATE TABLE IF NOT EXISTS page_views (
   id bigserial PRIMARY KEY,

--- a/jamesduxbury/src/db/seed.ts
+++ b/jamesduxbury/src/db/seed.ts
@@ -61,6 +61,12 @@ export async function seed(sql: NeonQueryFunction<false, false>): Promise<Record
     `;
   }
 
+  await sql`
+    INSERT INTO site_settings (profile_image)
+    VALUES ('/images/profile-picture.png')
+    ON CONFLICT (id) DO NOTHING
+  `;
+
   const counts = (await sql`
     SELECT
       (SELECT count(*) FROM projects) AS projects,
@@ -68,7 +74,8 @@ export async function seed(sql: NeonQueryFunction<false, false>): Promise<Record
       (SELECT count(*) FROM education) AS education,
       (SELECT count(*) FROM certifications) AS certifications,
       (SELECT count(*) FROM skill_groups) AS skill_groups,
-      (SELECT count(*) FROM about_paragraphs) AS about_paragraphs
+      (SELECT count(*) FROM about_paragraphs) AS about_paragraphs,
+      (SELECT count(*) FROM site_settings) AS site_settings
   `) as Record<string, string>[];
   return counts[0];
 }

--- a/jamesduxbury/src/db/seed.ts
+++ b/jamesduxbury/src/db/seed.ts
@@ -5,6 +5,7 @@ import { degrees } from '@/data/education';
 import { certifications } from '@/data/certifications';
 import { skillGroups } from '@/data/skills';
 import { aboutParagraphs } from '@/data/about';
+import { siteSettings } from '@/data/site';
 
 // Insert-if-missing only: reseeding must never overwrite admin edits
 export async function seed(sql: NeonQueryFunction<false, false>): Promise<Record<string, string>> {
@@ -63,7 +64,7 @@ export async function seed(sql: NeonQueryFunction<false, false>): Promise<Record
 
   await sql`
     INSERT INTO site_settings (profile_image)
-    VALUES ('/images/profile-picture.png')
+    VALUES (${siteSettings.profileImage})
     ON CONFLICT (id) DO NOTHING
   `;
 

--- a/jamesduxbury/tests/admin-actions.test.ts
+++ b/jamesduxbury/tests/admin-actions.test.ts
@@ -30,6 +30,7 @@ vi.mock('../src/admin/images', async (importOriginal) => {
 });
 
 import { deleteItem, markMessageRead, saveItem } from '../src/admin/actions';
+import { siteSettings } from '../src/data/site';
 import { countRows, getRow, listRows, makeRoomAt } from '../src/admin/sql';
 import { SITE_ROUTES } from '../src/lib/site';
 
@@ -85,6 +86,7 @@ beforeEach(() => {
 afterAll(async () => {
   await sql`DELETE FROM projects WHERE slug LIKE 'test-admin-%'`;
   await sql`DELETE FROM certifications WHERE name LIKE 'test-admin-%'`;
+  await sql`UPDATE site_settings SET profile_image = ${siteSettings.profileImage} WHERE id = 1`;
   await sql`DELETE FROM about_paragraphs WHERE sort_order >= 9000`;
   await sql`DELETE FROM messages WHERE email = ${emailMarker}`;
 });
@@ -186,6 +188,29 @@ describe('image fields', () => {
     const rows = await sql`SELECT 1 FROM certifications WHERE id = ${id}`;
     expect(rows).toHaveLength(0);
     expect(deleteImageMock).toHaveBeenCalledWith(urlTwo);
+  });
+});
+
+describe('site settings singleton', () => {
+  it('updates the profile image in place', async () => {
+    const url = 'https://abc.public.blob.vercel-storage.com/profile.png';
+    uploadMock.mockResolvedValue(url);
+    const fd = new FormData();
+    fd.append('profile_image', new File([new Uint8Array(8)], 'profile.png', { type: 'image/png' }));
+    await expect(saveItem('site', 1, EMPTY, fd)).rejects.toThrow('REDIRECT:/admin/site');
+    const [row] = await sql`SELECT profile_image FROM site_settings WHERE id = 1`;
+    expect(row.profile_image).toBe(url);
+    expect(deleteImageMock).toHaveBeenCalledWith(siteSettings.profileImage);
+  });
+
+  it('rejects a second settings row', async () => {
+    const fd = new FormData();
+    fd.append('profile_image', new File([new Uint8Array(8)], 'extra.png', { type: 'image/png' }));
+    uploadMock.mockResolvedValue('https://abc.public.blob.vercel-storage.com/extra.png');
+    const state = await saveItem('site', null, EMPTY, fd);
+    expect(state.message).toBeTruthy();
+    const rows = await sql`SELECT id FROM site_settings`;
+    expect(rows).toHaveLength(1);
   });
 });
 

--- a/jamesduxbury/tests/admin-actions.test.ts
+++ b/jamesduxbury/tests/admin-actions.test.ts
@@ -18,6 +18,17 @@ vi.mock('next/navigation', () => ({
   },
 }));
 
+const uploadMock = vi.fn<(file: File) => Promise<string>>();
+const deleteImageMock = vi.fn<(url: unknown) => Promise<void>>();
+vi.mock('../src/admin/images', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/admin/images')>();
+  return {
+    ...actual,
+    uploadImage: (file: File) => uploadMock(file),
+    deleteImage: (url: unknown) => deleteImageMock(url),
+  };
+});
+
 import { deleteItem, markMessageRead, saveItem } from '../src/admin/actions';
 import { countRows, getRow, listRows, makeRoomAt } from '../src/admin/sql';
 import { SITE_ROUTES } from '../src/lib/site';
@@ -66,10 +77,14 @@ function projectForm(overrides: Record<string, string | string[]> = {}): FormDat
 beforeEach(() => {
   authMock.mockResolvedValue(session);
   revalidated.length = 0;
+  uploadMock.mockReset();
+  deleteImageMock.mockReset();
+  deleteImageMock.mockResolvedValue(undefined);
 });
 
 afterAll(async () => {
   await sql`DELETE FROM projects WHERE slug LIKE 'test-admin-%'`;
+  await sql`DELETE FROM certifications WHERE name LIKE 'test-admin-%'`;
   await sql`DELETE FROM about_paragraphs WHERE sort_order >= 9000`;
   await sql`DELETE FROM messages WHERE email = ${emailMarker}`;
 });
@@ -97,6 +112,80 @@ describe('validation', () => {
   it('rejects an out-of-range metric ratio', async () => {
     const state = await saveItem('projects', null, EMPTY, projectForm({ 'metrics.ratio': ['1.5', ''] }));
     expect(state.fieldErrors.metrics).toBeTruthy();
+  });
+});
+
+describe('image fields', () => {
+  const certName = `${marker}-cert`;
+  const urlOne = 'https://abc.public.blob.vercel-storage.com/one.png';
+  const urlTwo = 'https://abc.public.blob.vercel-storage.com/two.png';
+
+  function certForm(file?: File): FormData {
+    const fd = form({ name: certName, year: '2026', certification_link: '', sort_order: '960' });
+    if (file) fd.append('img_path', file);
+    return fd;
+  }
+
+  function png(name: string): File {
+    return new File([new Uint8Array(8)], name, { type: 'image/png' });
+  }
+
+  async function certId(): Promise<number> {
+    const [{ id }] = await sql`SELECT id FROM certifications WHERE name = ${certName}`;
+    return id as number;
+  }
+
+  it('uploads the file on create and stores its url', async () => {
+    uploadMock.mockResolvedValue(urlOne);
+    await expect(saveItem('certifications', null, EMPTY, certForm(png('one.png')))).rejects.toThrow(
+      'REDIRECT:/admin/certifications',
+    );
+    const [row] = await sql`SELECT img_path FROM certifications WHERE name = ${certName}`;
+    expect(row.img_path).toBe(urlOne);
+    expect(deleteImageMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps the stored image when no file is chosen', async () => {
+    await expect(saveItem('certifications', await certId(), EMPTY, certForm())).rejects.toThrow(
+      'REDIRECT:/admin/certifications',
+    );
+    const [row] = await sql`SELECT img_path FROM certifications WHERE name = ${certName}`;
+    expect(row.img_path).toBe(urlOne);
+    expect(uploadMock).not.toHaveBeenCalled();
+    expect(deleteImageMock).not.toHaveBeenCalled();
+  });
+
+  it('replaces the image and deletes the old blob', async () => {
+    uploadMock.mockResolvedValue(urlTwo);
+    await expect(
+      saveItem('certifications', await certId(), EMPTY, certForm(png('two.png'))),
+    ).rejects.toThrow('REDIRECT:/admin/certifications');
+    const [row] = await sql`SELECT img_path FROM certifications WHERE name = ${certName}`;
+    expect(row.img_path).toBe(urlTwo);
+    expect(deleteImageMock).toHaveBeenCalledWith(urlOne);
+  });
+
+  it('rejects a wrong mime type before uploading', async () => {
+    const gif = new File([new Uint8Array(8)], 'a.gif', { type: 'image/gif' });
+    const state = await saveItem('certifications', await certId(), EMPTY, certForm(gif));
+    expect(state.fieldErrors.img_path).toMatch(/png, jpeg or webp/);
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it('cleans up the uploaded blob when the insert fails', async () => {
+    uploadMock.mockResolvedValue(urlOne);
+    // duplicate name violates the unique constraint after the upload
+    const state = await saveItem('certifications', null, EMPTY, certForm(png('dupe.png')));
+    expect(state.message).toBeTruthy();
+    expect(deleteImageMock).toHaveBeenCalledWith(urlOne);
+  });
+
+  it('deletes the blob with the row', async () => {
+    const id = await certId();
+    await deleteItem('certifications', id);
+    const rows = await sql`SELECT 1 FROM certifications WHERE id = ${id}`;
+    expect(rows).toHaveLength(0);
+    expect(deleteImageMock).toHaveBeenCalledWith(urlTwo);
   });
 });
 

--- a/jamesduxbury/tests/admin-actions.test.ts
+++ b/jamesduxbury/tests/admin-actions.test.ts
@@ -174,6 +174,13 @@ describe('image fields', () => {
     expect(uploadMock).not.toHaveBeenCalled();
   });
 
+  it('fails the save and cleans up the blob when the row no longer exists', async () => {
+    uploadMock.mockResolvedValue(urlOne);
+    const state = await saveItem('certifications', 999999, EMPTY, certForm(png('gone.png')));
+    expect(state.message).toBe('Row no longer exists');
+    expect(deleteImageMock).toHaveBeenCalledWith(urlOne);
+  });
+
   it('cleans up the uploaded blob when the insert fails', async () => {
     uploadMock.mockResolvedValue(urlOne);
     // duplicate name violates the unique constraint after the upload

--- a/jamesduxbury/tests/admin-images.test.ts
+++ b/jamesduxbury/tests/admin-images.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+interface PutOptions {
+  access: string;
+  addRandomSuffix: boolean;
+}
+
+const putMock = vi.fn<(name: string, file: File, opts: PutOptions) => Promise<{ url: string }>>();
+const delMock = vi.fn<(url: string) => Promise<void>>();
+vi.mock('@vercel/blob', () => ({
+  put: (name: string, file: File, opts: PutOptions) => putMock(name, file, opts),
+  del: (url: string) => delMock(url),
+}));
+
+import { deleteImage, imageFileError, isBlobUrl, uploadImage } from '../src/admin/images';
+
+const BLOB_URL = 'https://abc123.public.blob.vercel-storage.com/profile-x1y2.png';
+
+function makeFile(name: string, type: string, bytes = 16): File {
+  return new File([new Uint8Array(bytes)], name, { type });
+}
+
+beforeEach(() => {
+  putMock.mockReset();
+  delMock.mockReset();
+});
+
+describe('imageFileError', () => {
+  it('accepts png, jpeg and webp', () => {
+    expect(imageFileError(makeFile('a.png', 'image/png'))).toBeNull();
+    expect(imageFileError(makeFile('a.jpg', 'image/jpeg'))).toBeNull();
+    expect(imageFileError(makeFile('a.webp', 'image/webp'))).toBeNull();
+  });
+
+  it('rejects other mime types', () => {
+    expect(imageFileError(makeFile('a.gif', 'image/gif'))).toMatch(/png, jpeg or webp/);
+    expect(imageFileError(makeFile('a.svg', 'image/svg+xml'))).toMatch(/png, jpeg or webp/);
+    expect(imageFileError(makeFile('a.txt', 'text/plain'))).toMatch(/png, jpeg or webp/);
+  });
+
+  it('rejects files over 4MB', () => {
+    expect(imageFileError(makeFile('big.png', 'image/png', 4 * 1024 * 1024 + 1))).toMatch(/4MB/);
+    expect(imageFileError(makeFile('ok.png', 'image/png', 4 * 1024 * 1024))).toBeNull();
+  });
+});
+
+describe('isBlobUrl', () => {
+  it('matches store-owned urls only', () => {
+    expect(isBlobUrl(BLOB_URL)).toBe(true);
+    expect(isBlobUrl('/images/profile-picture.png')).toBe(false);
+    expect(isBlobUrl('https://example.com/a.png')).toBe(false);
+    expect(isBlobUrl('https://evil.com/x.public.blob.vercel-storage.com')).toBe(false);
+    expect(isBlobUrl('not a url')).toBe(false);
+  });
+});
+
+describe('uploadImage', () => {
+  it('puts the file publicly with a random suffix and returns the url', async () => {
+    putMock.mockResolvedValue({ url: BLOB_URL });
+    const file = makeFile('profile.png', 'image/png');
+    await expect(uploadImage(file)).resolves.toBe(BLOB_URL);
+    expect(putMock).toHaveBeenCalledWith('profile.png', file, {
+      access: 'public',
+      addRandomSuffix: true,
+    });
+  });
+});
+
+describe('deleteImage', () => {
+  it('deletes store-owned urls', async () => {
+    delMock.mockResolvedValue(undefined);
+    await deleteImage(BLOB_URL);
+    expect(delMock).toHaveBeenCalledWith(BLOB_URL);
+  });
+
+  it('skips legacy paths and non-strings', async () => {
+    await deleteImage('/images/profile-picture.png');
+    await deleteImage(null);
+    await deleteImage(undefined);
+    expect(delMock).not.toHaveBeenCalled();
+  });
+
+  it('swallows delete failures', async () => {
+    delMock.mockRejectedValue(new Error('boom'));
+    await expect(deleteImage(BLOB_URL)).resolves.toBeUndefined();
+  });
+});

--- a/jamesduxbury/tests/admin-kit.test.ts
+++ b/jamesduxbury/tests/admin-kit.test.ts
@@ -143,7 +143,7 @@ describe('fieldDefault', () => {
 });
 
 describe('section registry', () => {
-  it('exposes the six content sections', () => {
+  it('exposes the seven content sections', () => {
     expect(SECTIONS.map((s) => s.slug)).toEqual([
       'projects',
       'experience',
@@ -151,6 +151,7 @@ describe('section registry', () => {
       'certifications',
       'skills',
       'about',
+      'site',
     ]);
   });
 
@@ -191,6 +192,7 @@ describe('section registry', () => {
     certifications: { name: 'Cert', year: '2024', sort_order: '1' },
     skills: { heading: 'Languages', skills: 'Python, TypeScript', sort_order: '1' },
     about: { runs: 'plain **bold**', sort_order: '1' },
+    site: {},
   };
 
   it.each(SECTIONS.map((s) => [s.slug] as const))(
@@ -202,11 +204,15 @@ describe('section registry', () => {
     },
   );
 
-  it.each(SECTIONS.map((s) => [s.slug] as const))('%s: an empty form fails validation', (slug) => {
-    const section = getSection(slug);
-    const parsed = section.schema.safeParse(parseFields(section.fields, form({})));
-    expect(parsed.success).toBe(false);
-  });
+  // site has no required text inputs: its only field is the upload the action fills
+  it.each(SECTIONS.filter((s) => s.slug !== 'site').map((s) => [s.slug] as const))(
+    '%s: an empty form fails validation',
+    (slug) => {
+      const section = getSection(slug);
+      const parsed = section.schema.safeParse(parseFields(section.fields, form({})));
+      expect(parsed.success).toBe(false);
+    },
+  );
 
   it('labels rows for every section list page', () => {
     expect(getSection('projects').listLabel({ title: 'FG-HAN' })).toBe('FG-HAN');
@@ -216,6 +222,7 @@ describe('section registry', () => {
     expect(getSection('education').listLabel({ qualification: 'MEng' })).toBe('MEng');
     expect(getSection('certifications').listLabel({ name: 'ITIL 4' })).toBe('ITIL 4');
     expect(getSection('skills').listLabel({ heading: 'Languages' })).toBe('Languages');
+    expect(getSection('site').listLabel({})).toBe('Site settings');
     expect(getSection('about').listLabel({ runs: ['plain ', { strong: 'bold' }] })).toBe(
       'plain bold',
     );

--- a/jamesduxbury/tests/admin-kit.test.ts
+++ b/jamesduxbury/tests/admin-kit.test.ts
@@ -50,6 +50,7 @@ describe('parseFields', () => {
     { column: 'tags', label: 'Tags', type: 'tags' },
     { column: 'metrics', label: 'Metrics', type: 'metrics' },
     { column: 'runs', label: 'Runs', type: 'runs' },
+    { column: 'image', label: 'Image', type: 'image' },
   ];
 
   it('maps every field type to its DB value', () => {
@@ -80,6 +81,7 @@ describe('parseFields', () => {
       tags: ['a', 'b', 'c'],
       metrics: [{ label: 'F1', value: '0.9', ratio: 0.9 }],
       runs: ['hello ', { strong: 'world' }],
+      image: null,
     });
   });
 
@@ -96,6 +98,7 @@ describe('parseFields', () => {
       tags: [],
       metrics: null,
       runs: [],
+      image: null,
     });
   });
 
@@ -130,6 +133,8 @@ describe('fieldDefault', () => {
       ],
       [{ column: 'c', label: 'c', type: 'metrics' }, null, []],
       [{ column: 'c', label: 'c', type: 'runs' }, ['a ', { strong: 'b' }], 'a **b**'],
+      [{ column: 'c', label: 'c', type: 'image' }, 'https://blob/x.png', 'https://blob/x.png'],
+      [{ column: 'c', label: 'c', type: 'image' }, null, ''],
     ];
     for (const [def, dbValue, expected] of cases) {
       expect(fieldDefault(def, dbValue)).toEqual(expected);

--- a/jamesduxbury/tests/admin-ui.dom.test.tsx
+++ b/jamesduxbury/tests/admin-ui.dom.test.tsx
@@ -94,8 +94,10 @@ describe('SectionForm', () => {
     { column: 'bullets', label: 'Bullets', type: 'bullets' },
     { column: 'metrics', label: 'Metrics', type: 'metrics' },
     { column: 'runs', label: 'Paragraph', type: 'runs' },
+    { column: 'image', label: 'Image', type: 'image' },
   ];
   const defaults = {
+    image: 'https://abc.public.blob.vercel-storage.com/existing.png',
     title: 'Existing',
     notes: 'note text',
     link: 'https://example.com',
@@ -127,6 +129,13 @@ describe('SectionForm', () => {
     expect(screen.getByDisplayValue('second')).toBeInTheDocument();
     expect(screen.getByDisplayValue('F1')).toBeInTheDocument();
     expect(screen.getByLabelText('Paragraph')).toHaveValue('plain **bold**');
+    const fileInput = screen.getByLabelText('Image');
+    expect(fileInput).toHaveAttribute('type', 'file');
+    expect(fileInput).toHaveAttribute('accept', 'image/png,image/jpeg,image/webp');
+    expect(screen.getByAltText('current image')).toHaveAttribute(
+      'src',
+      'https://abc.public.blob.vercel-storage.com/existing.png',
+    );
     expect(screen.getByRole('button', { name: 'save →' })).toBeInTheDocument();
   });
 

--- a/jamesduxbury/tests/seed-and-queries.test.ts
+++ b/jamesduxbury/tests/seed-and-queries.test.ts
@@ -16,6 +16,7 @@ import { degrees } from '../src/data/education';
 import { certifications } from '../src/data/certifications';
 import { skillGroups } from '../src/data/skills';
 import { aboutParagraphs } from '../src/data/about';
+import { siteSettings } from '../src/data/site';
 
 const sql = neon(process.env.DATABASE_URL!);
 
@@ -72,6 +73,6 @@ describe('queries round-trip the seeded src/data shapes exactly', () => {
   });
 
   it('site settings', async () => {
-    expect(await getSiteSettings()).toEqual({ profileImage: '/images/profile-picture.png' });
+    expect(await getSiteSettings()).toEqual(siteSettings);
   });
 });

--- a/jamesduxbury/tests/seed-and-queries.test.ts
+++ b/jamesduxbury/tests/seed-and-queries.test.ts
@@ -7,6 +7,7 @@ import {
   getDegrees,
   getProjects,
   getRoles,
+  getSiteSettings,
   getSkillGroups,
 } from '../src/db/queries';
 import { projects } from '../src/data/projects';
@@ -30,6 +31,7 @@ describe('seed', () => {
       certifications: String(certifications.length),
       skill_groups: String(skillGroups.length),
       about_paragraphs: String(aboutParagraphs.length),
+      site_settings: '1',
     });
   });
 
@@ -67,5 +69,9 @@ describe('queries round-trip the seeded src/data shapes exactly', () => {
 
   it('about paragraphs', async () => {
     expect(await getAboutParagraphs()).toEqual(aboutParagraphs);
+  });
+
+  it('site settings', async () => {
+    expect(await getSiteSettings()).toEqual({ profileImage: '/images/profile-picture.png' });
   });
 });

--- a/jamesduxbury/tests/ui.dom.test.tsx
+++ b/jamesduxbury/tests/ui.dom.test.tsx
@@ -51,7 +51,7 @@ describe('summary components render DB content', () => {
 
 describe('Entry', () => {
   it('renders the entry channel header', () => {
-    render(<Entry />);
+    render(<Entry profileImage="/images/profile-picture.png" />);
     expect(screen.getByText(/CHANNEL 00/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #24

Site images move from static files to Vercel Blob, uploaded and replaced from the admin console.

- `image` field type in the admin kit: upload with preview, empty input keeps the current image. Replacing an image deletes the old blob after the row update; deleting a row deletes its blobs; a failed save deletes the just-uploaded blob. Cleanup lives in the generic actions, so future sections inherit it.
- `site_settings` singleton (migration 0002) backs the profile picture, editable at /admin/site; certification and project images use the same field on their existing columns.
- `npm run images:migrate` uploads each environment's `/images` rows to the store. Run per environment, so dev and prod never share blobs and a replacement in one cannot break the other. Already run against dev; the dev blob URLs are baked into `src/data` as first-boot data.
- README gains the storage explanation and a blob lane in the diagram.

After merge and deploy: run `npm run images:migrate` with the production `DATABASE_URL`, verify, then a follow-up PR removes `public/images/`. The store token is already on Vercel (Production and Preview).

211 tests, coverage thresholds enforced, full gate green.