### PR TITLE
feat(work): per-project case-study pages at /work/[slug]

### DIFF
--- a/jamesduxbury/src/admin/actions.ts
+++ b/jamesduxbury/src/admin/actions.ts
@@ -33,7 +33,9 @@ function toSqlValues(fields: FieldDef[], data: Record<string, unknown>): Record<
   for (const f of fields) {
     const value = data[f.column];
     out[f.column] =
-      (f.type === 'metrics' || f.type === 'runs') && value !== null ? JSON.stringify(value) : value;
+      (f.type === 'metrics' || f.type === 'runs' || f.type === 'prose') && value !== null
+        ? JSON.stringify(value)
+        : value;
   }
   return out;
 }

--- a/jamesduxbury/src/admin/fields.ts
+++ b/jamesduxbury/src/admin/fields.ts
@@ -1,6 +1,6 @@
 import type { AboutParagraph } from '@/data/about';
 import type { ProjectMetric } from '@/data/projects';
-import { parseRuns, serialiseRuns } from './runs';
+import { parseProse, parseRuns, serialiseProse, serialiseRuns } from './runs';
 
 export type FieldType =
   | 'text'
@@ -14,6 +14,7 @@ export type FieldType =
   | 'checkbox'
   | 'metrics'
   | 'runs'
+  | 'prose'
   | 'image';
 
 export interface FieldDef {
@@ -84,6 +85,11 @@ export function parseFields(fields: FieldDef[], formData: FormData): Record<stri
       case 'runs':
         out[f.column] = parseRuns(text);
         break;
+      case 'prose': {
+        const paragraphs = parseProse(text);
+        out[f.column] = paragraphs.length ? paragraphs : null;
+        break;
+      }
       // the file is uploaded in the action, which fills the column
       case 'image':
         out[f.column] = null;
@@ -122,6 +128,8 @@ export function fieldDefault(f: FieldDef, value: unknown): FieldDefault {
         : [];
     case 'runs':
       return Array.isArray(value) ? serialiseRuns(value as AboutParagraph) : '';
+    case 'prose':
+      return Array.isArray(value) ? serialiseProse(value as AboutParagraph[]) : '';
     case 'number':
     case 'sort_order':
       return typeof value === 'number' ? String(value) : '';

--- a/jamesduxbury/src/admin/runs.ts
+++ b/jamesduxbury/src/admin/runs.ts
@@ -23,3 +23,16 @@ export function serialiseRuns(runs: AboutParagraph): string {
     })
     .join('');
 }
+
+// blank lines separate paragraphs
+export function parseProse(text: string): AboutParagraph[] {
+  return text
+    .split(/\n\s*\n/)
+    .map((p) => p.trim())
+    .filter(Boolean)
+    .map((p) => parseRuns(p.replace(/\n/g, ' ')));
+}
+
+export function serialiseProse(paragraphs: AboutParagraph[]): string {
+  return paragraphs.map(serialiseRuns).join('\n\n');
+}

--- a/jamesduxbury/src/admin/sections.ts
+++ b/jamesduxbury/src/admin/sections.ts
@@ -37,6 +37,9 @@ const runSchema = z.union([
   z.object({ em: z.string().min(1) }),
 ]);
 
+const proseSchema = z.array(z.array(runSchema).min(1)).min(1);
+const proseHelp = 'paragraphs separated by a blank line; **bold** and *italic* markup';
+
 export const SECTIONS: SectionConfig[] = [
   {
     slug: 'projects',
@@ -205,6 +208,31 @@ export const SECTIONS: SectionConfig[] = [
         : '';
       return text.length > 80 ? `${text.slice(0, 80)}…` : text;
     },
+  },
+  {
+    slug: 'case-studies',
+    table: 'case_studies',
+    title: 'Case studies',
+    fields: [
+      {
+        column: 'project_slug',
+        label: 'Project slug',
+        type: 'text',
+        help: 'slug of the project row',
+      },
+      { column: 'problem', label: 'Problem', type: 'prose', help: proseHelp },
+      { column: 'approach', label: 'Approach', type: 'prose', help: proseHelp },
+      { column: 'outcome', label: 'Outcome', type: 'prose', help: proseHelp },
+      imageField('image_path'),
+    ],
+    schema: z.object({
+      project_slug: z.string().regex(/^[a-z0-9-]+$/, 'lowercase letters, digits, and hyphens only'),
+      problem: proseSchema,
+      approach: proseSchema,
+      outcome: proseSchema.nullable(),
+      image_path: z.string().min(1).nullable(),
+    }),
+    listLabel: (row) => String(row.project_slug),
   },
   {
     slug: 'site',

--- a/jamesduxbury/src/app/opengraph-image.tsx
+++ b/jamesduxbury/src/app/opengraph-image.tsx
@@ -1,82 +1,30 @@
 import { ImageResponse } from 'next/og';
-import { SITE_HOST } from '@/lib/site';
+import { OG_COLOURS, OG_SIZE, OgFrame } from '@/lib/og';
 
 export const alt = 'James Duxbury — Software Engineer in AI and Cybersecurity';
-export const size = { width: 1200, height: 630 };
+export const size = OG_SIZE;
 export const contentType = 'image/png';
-
-// Mirrors the console theme in tailwind.config.ts (satori can't read Tailwind).
-const colours = {
-  bg: '#0A0A14',
-  border: '#2A2A35',
-  text: '#F5F5F0',
-  muted: '#8B8B95',
-  accent: '#3B82F6',
-  live: '#22C55E',
-};
 
 export default function OpenGraphImage() {
   return new ImageResponse(
-    <div
-      style={{
-        width: '100%',
-        height: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'space-between',
-        padding: '56px 72px',
-        backgroundColor: colours.bg,
-        backgroundImage: `radial-gradient(circle at 1px 1px, rgba(245, 245, 240, 0.08) 1px, transparent 0)`,
-        backgroundSize: '24px 24px',
-        color: colours.text,
-      }}
+    <OgFrame
+      header={
+        <>
+          <span style={{ color: OG_COLOURS.live }}>LIVE</span>
+          <span style={{ color: OG_COLOURS.border }}>·</span>
+          <span style={{ color: OG_COLOURS.text }}>JAMES DUXBURY</span>
+          <span>v2.0</span>
+        </>
+      }
+      footerLeft="MEng Computer Science · Durham"
     >
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: '14px',
-          fontSize: 26,
-          letterSpacing: '0.2em',
-          color: colours.muted,
-        }}
-      >
-        <div
-          style={{
-            width: 14,
-            height: 14,
-            borderRadius: '50%',
-            backgroundColor: colours.live,
-          }}
-        />
-        <span style={{ color: colours.live }}>LIVE</span>
-        <span style={{ color: colours.border }}>·</span>
-        <span style={{ color: colours.text }}>JAMES DUXBURY</span>
-        <span>v2.0</span>
-      </div>
-
       <div style={{ display: 'flex', flexDirection: 'column', gap: '18px' }}>
         <div style={{ fontSize: 86, fontWeight: 700, letterSpacing: '0.04em' }}>James Duxbury</div>
-        <div style={{ fontSize: 36, color: colours.accent, letterSpacing: '0.08em' }}>
+        <div style={{ fontSize: 36, color: OG_COLOURS.accent, letterSpacing: '0.08em' }}>
           Software Engineer — AI &amp; Cybersecurity
         </div>
       </div>
-
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          borderTop: `2px solid ${colours.border}`,
-          paddingTop: '28px',
-          fontSize: 24,
-          letterSpacing: '0.15em',
-          color: colours.muted,
-        }}
-      >
-        <span>MEng Computer Science · Durham</span>
-        <span>{SITE_HOST}</span>
-      </div>
-    </div>,
-    size,
+    </OgFrame>,
+    OG_SIZE,
   );
 }

--- a/jamesduxbury/src/app/sitemap.ts
+++ b/jamesduxbury/src/app/sitemap.ts
@@ -1,10 +1,19 @@
 import type { MetadataRoute } from 'next';
 import { SITE_ROUTES, SITE_URL } from '@/lib/site';
+import { getProjects } from '@/db/queries';
 
-export default function sitemap(): MetadataRoute.Sitemap {
-  return SITE_ROUTES.map((route) => ({
-    url: `${SITE_URL}${route === '/' ? '' : route}`,
-    changeFrequency: 'monthly',
-    priority: route === '/' ? 1 : 0.7,
-  }));
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const projects = await getProjects();
+  return [
+    ...SITE_ROUTES.map((route) => ({
+      url: `${SITE_URL}${route === '/' ? '' : route}`,
+      changeFrequency: 'monthly' as const,
+      priority: route === '/' ? 1 : 0.7,
+    })),
+    ...projects.map((p) => ({
+      url: `${SITE_URL}/work/${p.slug}`,
+      changeFrequency: 'monthly' as const,
+      priority: 0.6,
+    })),
+  ];
 }

--- a/jamesduxbury/src/app/work/[slug]/loading.tsx
+++ b/jamesduxbury/src/app/work/[slug]/loading.tsx
@@ -1,0 +1,27 @@
+import { PageShell } from '@/components/PageShell';
+import { SkeletonLine } from '@/components/skeleton/Skeleton';
+
+export default function CaseStudyLoading() {
+  return (
+    <PageShell
+      widthClass="max-w-4xl"
+      backHref="/work"
+      backLabel="/ work"
+      loadingLabel="loading case study"
+    >
+      <div className="border-b border-border pb-6">
+        <SkeletonLine length={16} textClassName="text-2xl sm:text-3xl" cursor />
+        <SkeletonLine length={32} className="mt-3" textClassName="text-sm" />
+        <SkeletonLine length={24} className="mt-3" textClassName="text-xs" />
+      </div>
+      <div className="mt-6 space-y-3 border border-border bg-surface/40 px-4 py-6 backdrop-blur-sm sm:px-6">
+        <SkeletonLine length={8} textClassName="text-xs" />
+        <SkeletonLine length={48} textClassName="text-sm" />
+        <SkeletonLine length={40} textClassName="text-sm" />
+        <SkeletonLine length={8} className="pt-3" textClassName="text-xs" />
+        <SkeletonLine length={48} textClassName="text-sm" />
+        <SkeletonLine length={36} textClassName="text-sm" />
+      </div>
+    </PageShell>
+  );
+}

--- a/jamesduxbury/src/app/work/[slug]/opengraph-image.tsx
+++ b/jamesduxbury/src/app/work/[slug]/opengraph-image.tsx
@@ -1,21 +1,11 @@
 import { ImageResponse } from 'next/og';
 import { formatYearRange } from '@/data/projects';
 import { getProjectBySlug } from '@/db/queries';
-import { SITE_HOST } from '@/lib/site';
+import { OG_COLOURS, OG_SIZE, OgFrame } from '@/lib/og';
 
 export const alt = 'Case study · James Duxbury';
-export const size = { width: 1200, height: 630 };
+export const size = OG_SIZE;
 export const contentType = 'image/png';
-
-// Mirrors the console theme in tailwind.config.ts (satori can't read Tailwind).
-const colours = {
-  bg: '#0A0A14',
-  border: '#2A2A35',
-  text: '#F5F5F0',
-  muted: '#8B8B95',
-  accent: '#3B82F6',
-  live: '#22C55E',
-};
 
 export default async function OpenGraphImage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
@@ -26,61 +16,24 @@ export default async function OpenGraphImage({ params }: { params: Promise<{ slu
   const status = (project?.status ?? 'live').toUpperCase();
 
   return new ImageResponse(
-    <div
-      style={{
-        width: '100%',
-        height: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'space-between',
-        padding: '56px 72px',
-        backgroundColor: colours.bg,
-        backgroundImage: `radial-gradient(circle at 1px 1px, rgba(245, 245, 240, 0.08) 1px, transparent 0)`,
-        backgroundSize: '24px 24px',
-        color: colours.text,
-      }}
+    <OgFrame
+      header={
+        <>
+          <span style={{ color: OG_COLOURS.live }}>{status}</span>
+          <span style={{ color: OG_COLOURS.border }}>·</span>
+          <span style={{ color: OG_COLOURS.text }}>CASE STUDY</span>
+          <span>{yearLabel}</span>
+        </>
+      }
+      footerLeft="James Duxbury"
     >
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: '14px',
-          fontSize: 26,
-          letterSpacing: '0.2em',
-          color: colours.muted,
-        }}
-      >
-        <div
-          style={{ width: 14, height: 14, borderRadius: '50%', backgroundColor: colours.live }}
-        />
-        <span style={{ color: colours.live }}>{status}</span>
-        <span style={{ color: colours.border }}>·</span>
-        <span style={{ color: colours.text }}>CASE STUDY</span>
-        <span>{yearLabel}</span>
-      </div>
-
       <div style={{ display: 'flex', flexDirection: 'column', gap: '18px' }}>
         <div style={{ fontSize: 78, fontWeight: 700, letterSpacing: '0.04em' }}>{title}</div>
-        <div style={{ fontSize: 34, color: colours.accent, letterSpacing: '0.08em' }}>
+        <div style={{ fontSize: 34, color: OG_COLOURS.accent, letterSpacing: '0.08em' }}>
           {subtitle}
         </div>
       </div>
-
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          borderTop: `2px solid ${colours.border}`,
-          paddingTop: '28px',
-          fontSize: 24,
-          letterSpacing: '0.15em',
-          color: colours.muted,
-        }}
-      >
-        <span>James Duxbury</span>
-        <span>{SITE_HOST}</span>
-      </div>
-    </div>,
-    size,
+    </OgFrame>,
+    OG_SIZE,
   );
 }

--- a/jamesduxbury/src/app/work/[slug]/opengraph-image.tsx
+++ b/jamesduxbury/src/app/work/[slug]/opengraph-image.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from 'next/og';
+import { formatYearRange } from '@/data/projects';
 import { getProjectBySlug } from '@/db/queries';
 import { SITE_HOST } from '@/lib/site';
 
@@ -16,15 +17,12 @@ const colours = {
   live: '#22C55E',
 };
 
-export default async function OpenGraphImage({ params }: { params: { slug: string } }) {
-  const project = await getProjectBySlug(params.slug);
+export default async function OpenGraphImage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const project = await getProjectBySlug(slug);
   const title = project?.title ?? 'Case study';
   const subtitle = project?.subtitle ?? '';
-  const yearLabel = project
-    ? project.yearEnd === project.yearStart
-      ? `${project.yearStart}`
-      : `${project.yearStart} — ${project.yearEnd}`
-    : '';
+  const yearLabel = project ? formatYearRange(project) : '';
   const status = (project?.status ?? 'live').toUpperCase();
 
   return new ImageResponse(

--- a/jamesduxbury/src/app/work/[slug]/opengraph-image.tsx
+++ b/jamesduxbury/src/app/work/[slug]/opengraph-image.tsx
@@ -1,0 +1,88 @@
+import { ImageResponse } from 'next/og';
+import { getProjectBySlug } from '@/db/queries';
+import { SITE_HOST } from '@/lib/site';
+
+export const alt = 'Case study · James Duxbury';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+// Mirrors the console theme in tailwind.config.ts (satori can't read Tailwind).
+const colours = {
+  bg: '#0A0A14',
+  border: '#2A2A35',
+  text: '#F5F5F0',
+  muted: '#8B8B95',
+  accent: '#3B82F6',
+  live: '#22C55E',
+};
+
+export default async function OpenGraphImage({ params }: { params: { slug: string } }) {
+  const project = await getProjectBySlug(params.slug);
+  const title = project?.title ?? 'Case study';
+  const subtitle = project?.subtitle ?? '';
+  const yearLabel = project
+    ? project.yearEnd === project.yearStart
+      ? `${project.yearStart}`
+      : `${project.yearStart} — ${project.yearEnd}`
+    : '';
+  const status = (project?.status ?? 'live').toUpperCase();
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        padding: '56px 72px',
+        backgroundColor: colours.bg,
+        backgroundImage: `radial-gradient(circle at 1px 1px, rgba(245, 245, 240, 0.08) 1px, transparent 0)`,
+        backgroundSize: '24px 24px',
+        color: colours.text,
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '14px',
+          fontSize: 26,
+          letterSpacing: '0.2em',
+          color: colours.muted,
+        }}
+      >
+        <div
+          style={{ width: 14, height: 14, borderRadius: '50%', backgroundColor: colours.live }}
+        />
+        <span style={{ color: colours.live }}>{status}</span>
+        <span style={{ color: colours.border }}>·</span>
+        <span style={{ color: colours.text }}>CASE STUDY</span>
+        <span>{yearLabel}</span>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '18px' }}>
+        <div style={{ fontSize: 78, fontWeight: 700, letterSpacing: '0.04em' }}>{title}</div>
+        <div style={{ fontSize: 34, color: colours.accent, letterSpacing: '0.08em' }}>
+          {subtitle}
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          borderTop: `2px solid ${colours.border}`,
+          paddingTop: '28px',
+          fontSize: 24,
+          letterSpacing: '0.15em',
+          color: colours.muted,
+        }}
+      >
+        <span>James Duxbury</span>
+        <span>{SITE_HOST}</span>
+      </div>
+    </div>,
+    size,
+  );
+}

--- a/jamesduxbury/src/app/work/[slug]/page.tsx
+++ b/jamesduxbury/src/app/work/[slug]/page.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { PageShell } from '@/components/PageShell';
+import { CaseStudyDetail } from '@/components/work/CaseStudyDetail';
+import { getCaseStudy, getProjectBySlug, getProjects } from '@/db/queries';
+
+export const revalidate = 60;
+
+export async function generateStaticParams() {
+  return (await getProjects()).map((p) => ({ slug: p.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const project = await getProjectBySlug(slug);
+  if (!project) return {};
+  return {
+    title: `${project.title} · James Duxbury`,
+    description: project.subtitle,
+  };
+}
+
+export default async function CaseStudyPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const project = await getProjectBySlug(slug);
+  if (!project) notFound();
+  const study = await getCaseStudy(slug);
+
+  return (
+    <PageShell widthClass="max-w-4xl" backHref="/work" backLabel="/ work">
+      <CaseStudyDetail project={project} study={study} />
+    </PageShell>
+  );
+}

--- a/jamesduxbury/src/components/PageShell.tsx
+++ b/jamesduxbury/src/components/PageShell.tsx
@@ -4,11 +4,19 @@ import { Footer } from '@/components/Footer';
 interface PageShellProps {
   widthClass: string;
   loadingLabel?: string;
+  backHref?: string;
+  backLabel?: string;
   children: React.ReactNode;
 }
 
-// page chrome shared by the six section pages and their loading skeletons
-export function PageShell({ widthClass, loadingLabel, children }: PageShellProps) {
+// page chrome shared by the section pages and their loading skeletons
+export function PageShell({
+  widthClass,
+  loadingLabel,
+  backHref = '/',
+  backLabel = '/ home',
+  children,
+}: PageShellProps) {
   return (
     <>
       <main
@@ -17,10 +25,10 @@ export function PageShell({ widthClass, loadingLabel, children }: PageShellProps
         className={`mx-auto ${widthClass} px-4 pb-10 pt-28 sm:px-6 sm:pt-32`}
       >
         <Link
-          href="/"
+          href={backHref}
           className="mb-8 inline-block font-mono text-xs uppercase tracking-[0.2em] text-muted transition-colors hover:text-accent"
         >
-          ← / home
+          ← {backLabel}
         </Link>
         {children}
       </main>

--- a/jamesduxbury/src/components/admin/SectionForm.tsx
+++ b/jamesduxbury/src/components/admin/SectionForm.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import Image from 'next/image';
-import { useActionState, useState } from 'react';
+import { useActionState, useRef, useState } from 'react';
 import type { FormState } from '@/admin/actions';
 import type { FieldDef, FieldDefault, MetricDraft } from '@/admin/fields';
+import { parseProse } from '@/admin/runs';
+import { renderRun } from '@/components/about/renderRun';
 
 const INITIAL_STATE: FormState = { message: null, fieldErrors: {} };
 
@@ -113,6 +115,57 @@ function MetricsField({ column, initial }: { column: string; initial: MetricDraf
   );
 }
 
+function ProseField({ column, initial }: { column: string; initial: string }) {
+  const [text, setText] = useState(initial);
+  const area = useRef<HTMLTextAreaElement>(null);
+
+  // wraps the current selection in markup and restores it
+  const wrap = (marker: string) => {
+    const el = area.current;
+    if (!el) return;
+    const { selectionStart: start, selectionEnd: end } = el;
+    setText(text.slice(0, start) + marker + text.slice(start, end) + marker + text.slice(end));
+    requestAnimationFrame(() => {
+      el.focus();
+      el.setSelectionRange(start + marker.length, end + marker.length);
+    });
+  };
+
+  const paragraphs = parseProse(text);
+
+  return (
+    <div>
+      <div className="mt-2 flex gap-4">
+        <button type="button" onClick={() => wrap('**')} className={addButton + ' mt-0'}>
+          bold
+        </button>
+        <button type="button" onClick={() => wrap('*')} className={addButton + ' mt-0'}>
+          italic
+        </button>
+      </div>
+      <textarea
+        ref={area}
+        id={column}
+        name={column}
+        rows={10}
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        className={`${fieldInput} resize-y`}
+      />
+      {paragraphs.length > 0 && (
+        <div className="mt-3 border border-border px-4 py-3">
+          <p className={fieldLabel}>preview</p>
+          {paragraphs.map((p, i) => (
+            <p key={i} className="mt-2 font-mono text-sm leading-relaxed text-text/85">
+              {p.map(renderRun)}
+            </p>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function FieldInput({ field, defaultValue }: { field: FieldDef; defaultValue: FieldDefault }) {
   const text = typeof defaultValue === 'string' ? defaultValue : '';
   switch (field.type) {
@@ -190,6 +243,8 @@ function FieldInput({ field, defaultValue }: { field: FieldDef; defaultValue: Fi
           className={fieldInput}
         />
       );
+    case 'prose':
+      return <ProseField column={field.column} initial={text} />;
     case 'image':
       return (
         <div className="mt-2">

--- a/jamesduxbury/src/components/work/CaseStudyDetail.tsx
+++ b/jamesduxbury/src/components/work/CaseStudyDetail.tsx
@@ -1,10 +1,10 @@
 import Image from 'next/image';
-import Link from 'next/link';
 import type { CaseStudy } from '@/data/case-studies';
-import type { Project } from '@/data/projects';
+import { formatYearRange, type Project } from '@/data/projects';
 import { StatusChip } from '@/components/console/StatusChip';
 import { renderRun } from '@/components/about/renderRun';
 import { MetricBar } from './MetricBar';
+import { ProjectLinks } from './ProjectLinks';
 
 interface CaseStudyDetailProps {
   project: Project;
@@ -25,10 +25,7 @@ function ProseSection({ label, paragraphs }: { label: string; paragraphs: CaseSt
 }
 
 export function CaseStudyDetail({ project, study }: CaseStudyDetailProps) {
-  const yearLabel =
-    project.yearEnd === project.yearStart
-      ? `${project.yearStart}`
-      : `${project.yearStart} — ${project.yearEnd}`;
+  const yearLabel = formatYearRange(project);
 
   return (
     <article>
@@ -47,30 +44,7 @@ export function CaseStudyDetail({ project, study }: CaseStudyDetailProps) {
           {project.subtitle}
         </p>
         <p className="mt-3 font-mono text-xs text-muted">{project.techStack.join('  ·  ')}</p>
-        {(project.githubLink || project.liveLink) && (
-          <div className="mt-4 flex flex-wrap items-center gap-4 font-mono text-xs">
-            {project.githubLink && (
-              <Link
-                href={project.githubLink}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 text-accent transition-colors hover:text-danger"
-              >
-                view repo ↗
-              </Link>
-            )}
-            {project.liveLink && (
-              <Link
-                href={project.liveLink}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 text-accent transition-colors hover:text-danger"
-              >
-                open live ↗
-              </Link>
-            )}
-          </div>
-        )}
+        <ProjectLinks githubLink={project.githubLink} liveLink={project.liveLink} />
       </header>
 
       {study ? (

--- a/jamesduxbury/src/components/work/CaseStudyDetail.tsx
+++ b/jamesduxbury/src/components/work/CaseStudyDetail.tsx
@@ -1,0 +1,113 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import type { CaseStudy } from '@/data/case-studies';
+import type { Project } from '@/data/projects';
+import { StatusChip } from '@/components/console/StatusChip';
+import { renderRun } from '@/components/about/renderRun';
+import { MetricBar } from './MetricBar';
+
+interface CaseStudyDetailProps {
+  project: Project;
+  study: CaseStudy | null;
+}
+
+function ProseSection({ label, paragraphs }: { label: string; paragraphs: CaseStudy['problem'] }) {
+  return (
+    <section className="border-b border-border px-4 py-6 last:border-b-0 sm:px-6">
+      <h2 className="font-mono text-xs uppercase tracking-[0.2em] text-muted">{label}</h2>
+      {paragraphs.map((p, i) => (
+        <p key={i} className="mt-3 text-sm leading-relaxed text-text/85 sm:text-base">
+          {p.map(renderRun)}
+        </p>
+      ))}
+    </section>
+  );
+}
+
+export function CaseStudyDetail({ project, study }: CaseStudyDetailProps) {
+  const yearLabel =
+    project.yearEnd === project.yearStart
+      ? `${project.yearStart}`
+      : `${project.yearStart} — ${project.yearEnd}`;
+
+  return (
+    <article>
+      <header className="border-b border-border pb-6">
+        <div className="flex flex-wrap items-baseline gap-x-4 gap-y-2">
+          <h1 className="font-mono text-2xl font-semibold text-text sm:text-3xl">
+            {project.title}
+          </h1>
+          <span className="font-mono text-xs text-muted">{yearLabel}</span>
+          <div className="ml-auto flex flex-wrap items-center gap-2">
+            <StatusChip kind={project.status} />
+            {project.underExam && <StatusChip kind="exam" />}
+          </div>
+        </div>
+        <p className="mt-3 font-mono text-sm uppercase tracking-[0.15em] text-text/70">
+          {project.subtitle}
+        </p>
+        <p className="mt-3 font-mono text-xs text-muted">{project.techStack.join('  ·  ')}</p>
+        {(project.githubLink || project.liveLink) && (
+          <div className="mt-4 flex flex-wrap items-center gap-4 font-mono text-xs">
+            {project.githubLink && (
+              <Link
+                href={project.githubLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-accent transition-colors hover:text-danger"
+              >
+                view repo ↗
+              </Link>
+            )}
+            {project.liveLink && (
+              <Link
+                href={project.liveLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-accent transition-colors hover:text-danger"
+              >
+                open live ↗
+              </Link>
+            )}
+          </div>
+        )}
+      </header>
+
+      {study ? (
+        <div className="mt-6 border border-border bg-surface/40 backdrop-blur-sm">
+          {study.imagePath && (
+            <div className="border-b border-border">
+              <Image
+                src={study.imagePath}
+                alt={`${project.title} illustration`}
+                width={1200}
+                height={675}
+                className="h-auto w-full object-cover"
+              />
+            </div>
+          )}
+          <ProseSection label="Problem" paragraphs={study.problem} />
+          <ProseSection label="Approach" paragraphs={study.approach} />
+          {study.outcome && <ProseSection label="Outcome" paragraphs={study.outcome} />}
+          {project.metrics && <MetricBar metrics={project.metrics} />}
+        </div>
+      ) : (
+        <div className="mt-6 border border-border bg-surface/40 px-4 py-6 backdrop-blur-sm sm:px-6">
+          <p className="font-mono text-xs uppercase tracking-[0.2em] text-muted">
+            {project.underExam ? 'under examination' : 'case study'}
+          </p>
+          <p className="mt-3 text-sm leading-relaxed text-text/85 sm:text-base">
+            {project.underExam
+              ? 'The full write-up follows once marking completes. The highlights below cover the current state.'
+              : 'The full write-up is in preparation. The highlights below cover the current state.'}
+          </p>
+          <ul className="mt-4 list-disc space-y-2 pl-5 text-sm leading-relaxed text-text/85 sm:text-base">
+            {project.highlights.map((point, i) => (
+              <li key={i}>{point}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </article>
+  );
+}

--- a/jamesduxbury/src/components/work/ProjectLinks.tsx
+++ b/jamesduxbury/src/components/work/ProjectLinks.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link';
+
+export const projectLinkClass =
+  'inline-flex items-center gap-1 text-accent transition-colors hover:text-danger';
+
+interface ProjectLinksProps {
+  githubLink?: string;
+  liveLink?: string;
+  children?: React.ReactNode;
+}
+
+export function ProjectLinks({ githubLink, liveLink, children }: ProjectLinksProps) {
+  if (!githubLink && !liveLink && !children) return null;
+  return (
+    <div className="mt-4 flex flex-wrap items-center gap-4 font-mono text-xs">
+      {children}
+      {githubLink && (
+        <Link
+          href={githubLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={projectLinkClass}
+        >
+          view repo ↗
+        </Link>
+      )}
+      {liveLink && (
+        <Link
+          href={liveLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={projectLinkClass}
+        >
+          open live ↗
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/jamesduxbury/src/components/work/ProjectRow.tsx
+++ b/jamesduxbury/src/components/work/ProjectRow.tsx
@@ -30,7 +30,9 @@ export const ProjectRow: React.FC<ProjectRowProps> = ({ project, index, variant 
             {positionLabel}
           </span>
           <h3 className="font-mono text-base font-semibold text-text sm:text-lg">
-            {project.title}
+            <Link href={`/work/${project.slug}`} className="transition-colors hover:text-accent">
+              {project.title}
+            </Link>
           </h3>
           <span className="font-mono text-xs text-muted">{yearLabel}</span>
           <div className="ml-auto flex flex-wrap items-center gap-2">
@@ -53,30 +55,34 @@ export const ProjectRow: React.FC<ProjectRowProps> = ({ project, index, variant 
               ))}
             </ul>
 
-            {(project.githubLink || project.liveLink) && (
-              <div className="mt-4 flex flex-wrap items-center gap-4 font-mono text-xs">
-                {project.githubLink && (
-                  <Link
-                    href={project.githubLink}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 text-accent transition-colors hover:text-danger"
-                  >
-                    view repo ↗
-                  </Link>
-                )}
-                {project.liveLink && (
-                  <Link
-                    href={project.liveLink}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 text-accent transition-colors hover:text-danger"
-                  >
-                    open live ↗
-                  </Link>
-                )}
-              </div>
-            )}
+            <div className="mt-4 flex flex-wrap items-center gap-4 font-mono text-xs">
+              <Link
+                href={`/work/${project.slug}`}
+                className="inline-flex items-center gap-1 text-accent transition-colors hover:text-danger"
+              >
+                case study →
+              </Link>
+              {project.githubLink && (
+                <Link
+                  href={project.githubLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-accent transition-colors hover:text-danger"
+                >
+                  view repo ↗
+                </Link>
+              )}
+              {project.liveLink && (
+                <Link
+                  href={project.liveLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-accent transition-colors hover:text-danger"
+                >
+                  open live ↗
+                </Link>
+              )}
+            </div>
           </>
         )}
       </div>

--- a/jamesduxbury/src/components/work/ProjectRow.tsx
+++ b/jamesduxbury/src/components/work/ProjectRow.tsx
@@ -1,7 +1,8 @@
 import Link from 'next/link';
-import type { Project } from '@/data/projects';
+import { formatYearRange, type Project } from '@/data/projects';
 import { StatusChip } from '@/components/console/StatusChip';
 import { MetricBar } from './MetricBar';
+import { ProjectLinks, projectLinkClass } from './ProjectLinks';
 
 interface ProjectRowProps {
   project: Project;
@@ -11,10 +12,7 @@ interface ProjectRowProps {
 
 export const ProjectRow: React.FC<ProjectRowProps> = ({ project, index, variant = 'detail' }) => {
   const positionLabel = `P${String(index + 1).padStart(1, '0')}`;
-  const yearLabel =
-    project.yearEnd === project.yearStart
-      ? `${project.yearStart}`
-      : `${project.yearStart} — ${project.yearEnd}`;
+  const yearLabel = formatYearRange(project);
 
   const techPreview =
     variant === 'compact'
@@ -55,34 +53,11 @@ export const ProjectRow: React.FC<ProjectRowProps> = ({ project, index, variant 
               ))}
             </ul>
 
-            <div className="mt-4 flex flex-wrap items-center gap-4 font-mono text-xs">
-              <Link
-                href={`/work/${project.slug}`}
-                className="inline-flex items-center gap-1 text-accent transition-colors hover:text-danger"
-              >
+            <ProjectLinks githubLink={project.githubLink} liveLink={project.liveLink}>
+              <Link href={`/work/${project.slug}`} className={projectLinkClass}>
                 case study →
               </Link>
-              {project.githubLink && (
-                <Link
-                  href={project.githubLink}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-accent transition-colors hover:text-danger"
-                >
-                  view repo ↗
-                </Link>
-              )}
-              {project.liveLink && (
-                <Link
-                  href={project.liveLink}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-accent transition-colors hover:text-danger"
-                >
-                  open live ↗
-                </Link>
-              )}
-            </div>
+            </ProjectLinks>
           </>
         )}
       </div>

--- a/jamesduxbury/src/data/case-studies.ts
+++ b/jamesduxbury/src/data/case-studies.ts
@@ -1,0 +1,79 @@
+import type { AboutParagraph } from './about';
+
+export interface CaseStudy {
+  projectSlug: string;
+  problem: AboutParagraph[];
+  approach: AboutParagraph[];
+  outcome?: AboutParagraph[];
+  imagePath?: string;
+}
+
+export const caseStudies: CaseStudy[] = [
+  {
+    projectSlug: 'researcher-agent',
+    problem: [
+      [
+        'Keeping up with the literature for an MEng thesis on ',
+        { strong: 'mental health classification and explainability' },
+        ' meant running the same Semantic Scholar searches most mornings and skimming dozens of abstracts, most of them irrelevant.',
+      ],
+      [
+        'The search needed automating end to end: fetch new papers, judge their relevance, summarise them, and land the result in my inbox before the day starts.',
+      ],
+    ],
+    approach: [
+      [
+        'A Python pipeline on a daily cron. A fetcher polls the ',
+        { strong: 'Semantic Scholar API' },
+        ' for fresh papers per configured query, a scorer asks ',
+        { strong: 'Gemini Flash' },
+        ' to rate relevance against the thesis topics, and a summariser writes the digest that is emailed out.',
+      ],
+      [
+        'Pipeline behaviour lives in an ',
+        { em: 'app_config' },
+        ' table in Neon Postgres, edited from a dashboard page. Swapping the Gemini model or changing a query is a config edit, not a deploy.',
+      ],
+      [
+        'CI enforces ',
+        { strong: '95% total coverage' },
+        ' with a 90% per-module floor, plus integration tests against a separate Neon branch.',
+      ],
+    ],
+    outcome: [
+      [
+        'A scored, summarised digest arrives every morning. The reading loop takes minutes instead of an hour, and query or model changes never touch the code.',
+      ],
+    ],
+  },
+  {
+    projectSlug: 'jamesduxbury-dot-com',
+    problem: [
+      [
+        'This site began as a static portfolio: every copy tweak, new role, or project update meant a code change and a redeploy. The content needed to be editable from anywhere, without giving up the engineered feel of the site.',
+      ],
+    ],
+    approach: [
+      [
+        'Rebuilt on ',
+        { strong: 'Next.js 15' },
+        ' with all content in ',
+        { strong: 'Neon Postgres' },
+        ' accessed through raw tagged-template SQL. No ORM: the whole data layer is two readable files.',
+      ],
+      [
+        'The admin console is schema-driven: each section is field config plus a Zod schema, and the list, create, edit, delete pages, forms, and SQL are all generic. Sign-in is GitHub OAuth with a single-account allowlist checked at four layers. Saves call ',
+        { em: 'revalidatePath' },
+        ', so public pages update instantly while normal traffic stays ISR-cached.',
+      ],
+      [
+        'First-party analytics with no cookies or IP addresses feed an admin dashboard, and site images live in Vercel Blob with upload, replace, and delete handled by the admin kit.',
+      ],
+    ],
+    outcome: [
+      [
+        'Content edits go live in seconds from a phone. The build carries 200+ tests with enforced coverage thresholds, CI against a Neon branch, and a deploy that migrates its own database first.',
+      ],
+    ],
+  },
+];

--- a/jamesduxbury/src/data/projects.ts
+++ b/jamesduxbury/src/data/projects.ts
@@ -94,6 +94,22 @@ export const projects: Project[] = [
     githubLink: 'https://github.com/jsduxie/opencv-xray-repair',
   },
   {
+    slug: 'jamesduxbury-dot-com',
+    title: 'jamesduxbury.com',
+    subtitle: 'This site: DB-backed portfolio with an admin console',
+    status: 'live',
+    yearStart: 2024,
+    yearEnd: 2026,
+    techStack: ['Next.js', 'TypeScript', 'Tailwind CSS', 'Neon Postgres', 'Vercel'],
+    highlights: [
+      'All content in Postgres behind a schema-driven admin console; edits are live on save without a redeploy.',
+      'GitHub OAuth sign-in with a single-account allowlist enforced at four layers.',
+      'First-party, privacy-light analytics with a custom dashboard; no cookies, IPs, or fingerprinting.',
+    ],
+    githubLink: 'https://github.com/jsduxie/jamesduxbury-dot-com',
+    liveLink: 'https://jamesduxbury-dot-com.vercel.app',
+  },
+  {
     slug: 'artemis-iii',
     title: 'Artemis III Landing Site Analysis',
     subtitle: 'Advanced visualisation coursework',

--- a/jamesduxbury/src/data/projects.ts
+++ b/jamesduxbury/src/data/projects.ts
@@ -25,6 +25,10 @@ export interface Project {
   metrics?: ProjectMetric[];
 }
 
+export function formatYearRange(p: Pick<Project, 'yearStart' | 'yearEnd'>): string {
+  return p.yearEnd === p.yearStart ? `${p.yearStart}` : `${p.yearStart} — ${p.yearEnd}`;
+}
+
 export const projects: Project[] = [
   {
     slug: 'fg-han',

--- a/jamesduxbury/src/db/migrations/0003_case_studies.sql
+++ b/jamesduxbury/src/db/migrations/0003_case_studies.sql
@@ -1,0 +1,12 @@
+-- one optional case study per project; prose columns hold paragraph runs
+CREATE TABLE IF NOT EXISTS case_studies (
+  id serial PRIMARY KEY,
+  project_slug text NOT NULL UNIQUE REFERENCES projects(slug) ON UPDATE CASCADE,
+  problem jsonb NOT NULL,
+  approach jsonb NOT NULL,
+  outcome jsonb,
+  image_path text,
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);

--- a/jamesduxbury/src/db/queries.ts
+++ b/jamesduxbury/src/db/queries.ts
@@ -6,6 +6,7 @@ import type { Certification } from '@/data/certifications';
 import type { SkillGroup } from '@/data/skills';
 import type { AboutParagraph } from '@/data/about';
 import { siteSettings, type SiteSettings } from '@/data/site';
+import type { CaseStudy } from '@/data/case-studies';
 
 interface ProjectRow {
   slug: string;
@@ -105,6 +106,35 @@ export async function getCertifications(): Promise<Certification[]> {
 export async function getSkillGroups(): Promise<SkillGroup[]> {
   const rows = (await getSql()`SELECT * FROM skill_groups ORDER BY sort_order`) as SkillGroup[];
   return rows.map((r) => ({ heading: r.heading, skills: r.skills }));
+}
+
+export async function getProjectBySlug(slug: string): Promise<Project | null> {
+  const projects = await getProjects();
+  return projects.find((p) => p.slug === slug) ?? null;
+}
+
+interface CaseStudyRow {
+  project_slug: string;
+  problem: AboutParagraph[];
+  approach: AboutParagraph[];
+  outcome: AboutParagraph[] | null;
+  image_path: string | null;
+}
+
+export async function getCaseStudy(slug: string): Promise<CaseStudy | null> {
+  const rows = (await getSql()`
+    SELECT project_slug, problem, approach, outcome, image_path
+    FROM case_studies WHERE project_slug = ${slug}
+  `) as CaseStudyRow[];
+  const r = rows[0];
+  if (!r) return null;
+  return {
+    projectSlug: r.project_slug,
+    problem: r.problem,
+    approach: r.approach,
+    outcome: r.outcome ?? undefined,
+    imagePath: r.image_path ?? undefined,
+  };
 }
 
 export async function getSiteSettings(): Promise<SiteSettings> {

--- a/jamesduxbury/src/db/schema.sql
+++ b/jamesduxbury/src/db/schema.sql
@@ -86,6 +86,19 @@ CREATE TABLE IF NOT EXISTS messages (
   created_at timestamptz NOT NULL DEFAULT now()
 );
 
+-- one optional case study per project; prose columns hold paragraph runs
+CREATE TABLE IF NOT EXISTS case_studies (
+  id serial PRIMARY KEY,
+  project_slug text NOT NULL UNIQUE REFERENCES projects(slug) ON UPDATE CASCADE,
+  problem jsonb NOT NULL,
+  approach jsonb NOT NULL,
+  outcome jsonb,
+  image_path text,
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
 -- single settings row; sort_order only satisfies the generic admin list ordering
 CREATE TABLE IF NOT EXISTS site_settings (
   id integer PRIMARY KEY DEFAULT 1 CHECK (id = 1),

--- a/jamesduxbury/src/db/seed.ts
+++ b/jamesduxbury/src/db/seed.ts
@@ -6,6 +6,7 @@ import { certifications } from '@/data/certifications';
 import { skillGroups } from '@/data/skills';
 import { aboutParagraphs } from '@/data/about';
 import { siteSettings } from '@/data/site';
+import { caseStudies } from '@/data/case-studies';
 
 // Insert-if-missing only: reseeding must never overwrite admin edits
 export async function seed(sql: NeonQueryFunction<false, false>): Promise<Record<string, string>> {
@@ -62,6 +63,15 @@ export async function seed(sql: NeonQueryFunction<false, false>): Promise<Record
     `;
   }
 
+  for (const [i, cs] of caseStudies.entries()) {
+    await sql`
+      INSERT INTO case_studies (project_slug, problem, approach, outcome, image_path, sort_order)
+      VALUES (${cs.projectSlug}, ${JSON.stringify(cs.problem)}, ${JSON.stringify(cs.approach)},
+        ${cs.outcome ? JSON.stringify(cs.outcome) : null}, ${cs.imagePath ?? null}, ${i})
+      ON CONFLICT (project_slug) DO NOTHING
+    `;
+  }
+
   await sql`
     INSERT INTO site_settings (profile_image)
     VALUES (${siteSettings.profileImage})
@@ -76,6 +86,7 @@ export async function seed(sql: NeonQueryFunction<false, false>): Promise<Record
       (SELECT count(*) FROM certifications) AS certifications,
       (SELECT count(*) FROM skill_groups) AS skill_groups,
       (SELECT count(*) FROM about_paragraphs) AS about_paragraphs,
+      (SELECT count(*) FROM case_studies) AS case_studies,
       (SELECT count(*) FROM site_settings) AS site_settings
   `) as Record<string, string>[];
   return counts[0];

--- a/jamesduxbury/src/lib/og.tsx
+++ b/jamesduxbury/src/lib/og.tsx
@@ -1,0 +1,71 @@
+import { SITE_HOST } from './site';
+
+// Mirrors the console theme in tailwind.config.ts (satori can't read Tailwind).
+export const OG_COLOURS = {
+  bg: '#0A0A14',
+  border: '#2A2A35',
+  text: '#F5F5F0',
+  muted: '#8B8B95',
+  accent: '#3B82F6',
+  live: '#22C55E',
+};
+
+export const OG_SIZE = { width: 1200, height: 630 };
+
+interface OgFrameProps {
+  header: React.ReactNode;
+  footerLeft: string;
+  children: React.ReactNode;
+}
+
+export function OgFrame({ header, footerLeft, children }: OgFrameProps) {
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        padding: '56px 72px',
+        backgroundColor: OG_COLOURS.bg,
+        backgroundImage: `radial-gradient(circle at 1px 1px, rgba(245, 245, 240, 0.08) 1px, transparent 0)`,
+        backgroundSize: '24px 24px',
+        color: OG_COLOURS.text,
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '14px',
+          fontSize: 26,
+          letterSpacing: '0.2em',
+          color: OG_COLOURS.muted,
+        }}
+      >
+        <div
+          style={{ width: 14, height: 14, borderRadius: '50%', backgroundColor: OG_COLOURS.live }}
+        />
+        {header}
+      </div>
+
+      {children}
+
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          borderTop: `2px solid ${OG_COLOURS.border}`,
+          paddingTop: '28px',
+          fontSize: 24,
+          letterSpacing: '0.15em',
+          color: OG_COLOURS.muted,
+        }}
+      >
+        <span>{footerLeft}</span>
+        <span>{SITE_HOST}</span>
+      </div>
+    </div>
+  );
+}

--- a/jamesduxbury/tests/admin-actions.test.ts
+++ b/jamesduxbury/tests/admin-actions.test.ts
@@ -198,6 +198,48 @@ describe('image fields', () => {
   });
 });
 
+describe('case studies prose round trip', () => {
+  // fg-han is seeded with no case study, so the slug is free for this test
+  afterAll(async () => {
+    await sql`DELETE FROM case_studies WHERE project_slug = 'fg-han'`;
+  });
+
+  function studyForm(overrides: Record<string, string | string[]> = {}): FormData {
+    return form({
+      project_slug: 'fg-han',
+      problem: 'the **hard** part\n\nsecond paragraph',
+      approach: 'built with *care*',
+      outcome: '',
+      ...overrides,
+    });
+  }
+
+  it('creates a study with parsed prose paragraphs', async () => {
+    await expect(saveItem('case-studies', null, EMPTY, studyForm())).rejects.toThrow(
+      'REDIRECT:/admin/case-studies',
+    );
+    const [row] = await sql`SELECT * FROM case_studies WHERE project_slug = 'fg-han'`;
+    expect(row.problem).toEqual([['the ', { strong: 'hard' }, ' part'], ['second paragraph']]);
+    expect(row.approach).toEqual([['built with ', { em: 'care' }]]);
+    expect(row.outcome).toBeNull();
+  });
+
+  it('rejects a study for a project that does not exist', async () => {
+    const state = await saveItem(
+      'case-studies',
+      null,
+      EMPTY,
+      studyForm({ project_slug: 'no-such-project' }),
+    );
+    expect(state.message).toBeTruthy();
+  });
+
+  it('rejects an empty problem', async () => {
+    const state = await saveItem('case-studies', null, EMPTY, studyForm({ problem: '' }));
+    expect(state.fieldErrors.problem).toBeTruthy();
+  });
+});
+
 describe('site settings singleton', () => {
   it('updates the profile image in place', async () => {
     const url = 'https://abc.public.blob.vercel-storage.com/profile.png';

--- a/jamesduxbury/tests/admin-kit.test.ts
+++ b/jamesduxbury/tests/admin-kit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { fieldDefault, parseFields, type FieldDef } from '../src/admin/fields';
-import { parseRuns, serialiseRuns } from '../src/admin/runs';
+import { parseProse, parseRuns, serialiseProse, serialiseRuns } from '../src/admin/runs';
 import { getSection, SECTIONS } from '../src/admin/sections';
 
 function form(entries: Record<string, string | string[]>): FormData {
@@ -37,6 +37,25 @@ describe('about runs markup', () => {
   });
 });
 
+describe('prose markup', () => {
+  it('splits paragraphs on blank lines and parses runs', () => {
+    expect(parseProse('one **two**\n\n\nthree\nwrapped')).toEqual([
+      ['one ', { strong: 'two' }],
+      ['three wrapped'],
+    ]);
+  });
+
+  it('round-trips through serialiseProse', () => {
+    const text = 'one **two**\n\n*three* four';
+    expect(serialiseProse(parseProse(text))).toBe(text);
+  });
+
+  it('parses empty input to no paragraphs', () => {
+    expect(parseProse('')).toEqual([]);
+    expect(parseProse('  \n\n  ')).toEqual([]);
+  });
+});
+
 describe('parseFields', () => {
   const defs: FieldDef[] = [
     { column: 'title', label: 'Title', type: 'text' },
@@ -51,6 +70,7 @@ describe('parseFields', () => {
     { column: 'metrics', label: 'Metrics', type: 'metrics' },
     { column: 'runs', label: 'Runs', type: 'runs' },
     { column: 'image', label: 'Image', type: 'image' },
+    { column: 'prose', label: 'Prose', type: 'prose' },
   ];
 
   it('maps every field type to its DB value', () => {
@@ -68,6 +88,7 @@ describe('parseFields', () => {
       'metrics.value': ['0.9', ''],
       'metrics.ratio': ['0.9', ''],
       runs: 'hello **world**',
+      prose: 'first *para*\n\nsecond para',
     });
     expect(parseFields(defs, fd)).toEqual({
       title: 'Spaced',
@@ -82,6 +103,10 @@ describe('parseFields', () => {
       metrics: [{ label: 'F1', value: '0.9', ratio: 0.9 }],
       runs: ['hello ', { strong: 'world' }],
       image: null,
+      prose: [
+        ['first ', { em: 'para' }],
+        ['second para'],
+      ],
     });
   });
 
@@ -99,6 +124,7 @@ describe('parseFields', () => {
       metrics: null,
       runs: [],
       image: null,
+      prose: null,
     });
   });
 
@@ -135,6 +161,12 @@ describe('fieldDefault', () => {
       [{ column: 'c', label: 'c', type: 'runs' }, ['a ', { strong: 'b' }], 'a **b**'],
       [{ column: 'c', label: 'c', type: 'image' }, 'https://blob/x.png', 'https://blob/x.png'],
       [{ column: 'c', label: 'c', type: 'image' }, null, ''],
+      [
+        { column: 'c', label: 'c', type: 'prose' },
+        [['a ', { strong: 'b' }], ['c']],
+        'a **b**\n\nc',
+      ],
+      [{ column: 'c', label: 'c', type: 'prose' }, null, ''],
     ];
     for (const [def, dbValue, expected] of cases) {
       expect(fieldDefault(def, dbValue)).toEqual(expected);
@@ -143,7 +175,7 @@ describe('fieldDefault', () => {
 });
 
 describe('section registry', () => {
-  it('exposes the seven content sections', () => {
+  it('exposes the eight content sections', () => {
     expect(SECTIONS.map((s) => s.slug)).toEqual([
       'projects',
       'experience',
@@ -151,6 +183,7 @@ describe('section registry', () => {
       'certifications',
       'skills',
       'about',
+      'case-studies',
       'site',
     ]);
   });
@@ -192,6 +225,11 @@ describe('section registry', () => {
     certifications: { name: 'Cert', year: '2024', sort_order: '1' },
     skills: { heading: 'Languages', skills: 'Python, TypeScript', sort_order: '1' },
     about: { runs: 'plain **bold**', sort_order: '1' },
+    'case-studies': {
+      project_slug: 'test-slug',
+      problem: 'the **problem** statement\n\nsecond paragraph',
+      approach: 'how it was built',
+    },
     site: {},
   };
 
@@ -223,6 +261,7 @@ describe('section registry', () => {
     expect(getSection('certifications').listLabel({ name: 'ITIL 4' })).toBe('ITIL 4');
     expect(getSection('skills').listLabel({ heading: 'Languages' })).toBe('Languages');
     expect(getSection('site').listLabel({})).toBe('Site settings');
+    expect(getSection('case-studies').listLabel({ project_slug: 'fg-han' })).toBe('fg-han');
     expect(getSection('about').listLabel({ runs: ['plain ', { strong: 'bold' }] })).toBe(
       'plain bold',
     );

--- a/jamesduxbury/tests/admin-ui.dom.test.tsx
+++ b/jamesduxbury/tests/admin-ui.dom.test.tsx
@@ -95,8 +95,10 @@ describe('SectionForm', () => {
     { column: 'metrics', label: 'Metrics', type: 'metrics' },
     { column: 'runs', label: 'Paragraph', type: 'runs' },
     { column: 'image', label: 'Image', type: 'image' },
+    { column: 'body', label: 'Body', type: 'prose' },
   ];
   const defaults = {
+    body: 'first **heavy**\n\nsecond',
     image: 'https://abc.public.blob.vercel-storage.com/existing.png',
     title: 'Existing',
     notes: 'note text',
@@ -129,6 +131,7 @@ describe('SectionForm', () => {
     expect(screen.getByDisplayValue('second')).toBeInTheDocument();
     expect(screen.getByDisplayValue('F1')).toBeInTheDocument();
     expect(screen.getByLabelText('Paragraph')).toHaveValue('plain **bold**');
+    expect(screen.getByLabelText('Body')).toHaveValue('first **heavy**\n\nsecond');
     const fileInput = screen.getByLabelText('Image');
     expect(fileInput).toHaveAttribute('type', 'file');
     expect(fileInput).toHaveAttribute('accept', 'image/png,image/jpeg,image/webp');
@@ -137,6 +140,28 @@ describe('SectionForm', () => {
       'https://abc.public.blob.vercel-storage.com/existing.png',
     );
     expect(screen.getByRole('button', { name: 'save →' })).toBeInTheDocument();
+  });
+
+  it('previews prose paragraphs as they are typed', () => {
+    render(
+      <SectionForm fields={fields} defaults={defaults} action={noopAction} submitLabel="save" />,
+    );
+    expect(screen.getByText('heavy')).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Body'), {
+      target: { value: 'now with *emphasis*\n\nand a second paragraph' },
+    });
+    expect(screen.getByText('emphasis')).toBeInTheDocument();
+    expect(screen.getByText('and a second paragraph')).toBeInTheDocument();
+  });
+
+  it('wraps the selection when a toolbar button is clicked', () => {
+    render(
+      <SectionForm fields={fields} defaults={defaults} action={noopAction} submitLabel="save" />,
+    );
+    const area = screen.getByLabelText('Body') as HTMLTextAreaElement;
+    area.setSelectionRange(0, 5);
+    fireEvent.click(screen.getByRole('button', { name: 'italic' }));
+    expect(area.value).toBe('*first* **heavy**\n\nsecond');
   });
 
   it('adds and removes bullet rows', () => {

--- a/jamesduxbury/tests/case-study.dom.test.tsx
+++ b/jamesduxbury/tests/case-study.dom.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { CaseStudyDetail } from '../src/components/work/CaseStudyDetail';
+import type { CaseStudy } from '../src/data/case-studies';
+import type { Project } from '../src/data/projects';
+
+const project: Project = {
+  slug: 'test-project',
+  title: 'Test Project',
+  subtitle: 'A project for testing',
+  status: 'live',
+  yearStart: 2025,
+  yearEnd: 2026,
+  techStack: ['TypeScript', 'Vitest'],
+  highlights: ['shipped a thing', 'tested a thing'],
+  githubLink: 'https://github.com/jsduxie/test',
+  metrics: [{ label: 'coverage', value: '96%', ratio: 0.96 }],
+};
+
+const study: CaseStudy = {
+  projectSlug: 'test-project',
+  problem: [['the ', { strong: 'problem' }, ' statement']],
+  approach: [['the approach'], ['with a ', { em: 'second' }, ' paragraph']],
+  outcome: [['the outcome']],
+};
+
+describe('CaseStudyDetail', () => {
+  it('renders the study sections with runs and metrics', () => {
+    render(<CaseStudyDetail project={project} study={study} />);
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Test Project');
+    expect(screen.getByText('Problem')).toBeInTheDocument();
+    expect(screen.getByText('problem')).toBeInTheDocument();
+    expect(screen.getByText('Approach')).toBeInTheDocument();
+    expect(screen.getByText('second')).toBeInTheDocument();
+    expect(screen.getByText('Outcome')).toBeInTheDocument();
+    expect(screen.getByText('coverage')).toBeInTheDocument();
+    expect(screen.getByText('view repo ↗')).toBeInTheDocument();
+    expect(screen.queryByText('shipped a thing')).not.toBeInTheDocument();
+  });
+
+  it('falls back to highlights with an under-examination notice', () => {
+    render(<CaseStudyDetail project={{ ...project, underExam: true }} study={null} />);
+    expect(screen.getByText('under examination')).toBeInTheDocument();
+    expect(screen.getByText('shipped a thing')).toBeInTheDocument();
+    expect(screen.getByText('tested a thing')).toBeInTheDocument();
+  });
+
+  it('falls back to a preparation notice for projects not under exam', () => {
+    render(<CaseStudyDetail project={project} study={null} />);
+    expect(screen.getByText(/in preparation/)).toBeInTheDocument();
+    expect(screen.getByText('shipped a thing')).toBeInTheDocument();
+  });
+});

--- a/jamesduxbury/tests/seed-and-queries.test.ts
+++ b/jamesduxbury/tests/seed-and-queries.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from 'vitest';
 import { seed } from '../src/db/seed';
 import {
   getAboutParagraphs,
+  getCaseStudy,
   getCertifications,
   getDegrees,
+  getProjectBySlug,
   getProjects,
   getRoles,
   getSiteSettings,
@@ -16,24 +18,20 @@ import { degrees } from '../src/data/education';
 import { certifications } from '../src/data/certifications';
 import { skillGroups } from '../src/data/skills';
 import { aboutParagraphs } from '../src/data/about';
+import { caseStudies } from '../src/data/case-studies';
 import { siteSettings } from '../src/data/site';
 
 const sql = neon(process.env.DATABASE_URL!);
 
 describe('seed', () => {
+  // counts compare run-to-run, not to absolute sizes: other branches seed rows into the shared dev DB
   it('is idempotent: two runs leave identical counts', async () => {
     const first = await seed(sql);
     const second = await seed(sql);
     expect(second).toEqual(first);
-    expect(first).toEqual({
-      projects: String(projects.length),
-      experience: String(roles.length),
-      education: String(degrees.length),
-      certifications: String(certifications.length),
-      skill_groups: String(skillGroups.length),
-      about_paragraphs: String(aboutParagraphs.length),
-      site_settings: '1',
-    });
+    expect(Number(first.projects)).toBeGreaterThanOrEqual(projects.length);
+    expect(Number(first.case_studies)).toBeGreaterThanOrEqual(caseStudies.length);
+    expect(first.site_settings).toBe('1');
   });
 
   it('does not overwrite existing rows', async () => {
@@ -47,25 +45,30 @@ describe('seed', () => {
 
 describe('queries round-trip the seeded src/data shapes exactly', () => {
   it('projects', async () => {
-    expect(await getProjects()).toEqual(
-      projects.map((p) => ({ ...p, underExam: p.underExam ?? false })),
-    );
+    const bySlug = new Map((await getProjects()).map((p) => [p.slug, p]));
+    for (const p of projects) {
+      expect(bySlug.get(p.slug)).toEqual({ ...p, underExam: p.underExam ?? false });
+    }
   });
 
   it('roles, including present-role mapping', async () => {
-    expect(await getRoles()).toEqual(roles);
+    const byKey = new Map((await getRoles()).map((r) => [`${r.title}|${r.organisation}`, r]));
+    for (const r of roles) expect(byKey.get(`${r.title}|${r.organisation}`)).toEqual(r);
   });
 
   it('degrees', async () => {
-    expect(await getDegrees()).toEqual(degrees);
+    const byKey = new Map((await getDegrees()).map((d) => [d.qualification, d]));
+    for (const d of degrees) expect(byKey.get(d.qualification)).toEqual(d);
   });
 
   it('certifications', async () => {
-    expect(await getCertifications()).toEqual(certifications);
+    const byName = new Map((await getCertifications()).map((c) => [c.name, c]));
+    for (const c of certifications) expect(byName.get(c.name)).toEqual(c);
   });
 
   it('skill groups', async () => {
-    expect(await getSkillGroups()).toEqual(skillGroups);
+    const byHeading = new Map((await getSkillGroups()).map((g) => [g.heading, g]));
+    for (const g of skillGroups) expect(byHeading.get(g.heading)).toEqual(g);
   });
 
   it('about paragraphs', async () => {
@@ -74,5 +77,18 @@ describe('queries round-trip the seeded src/data shapes exactly', () => {
 
   it('site settings', async () => {
     expect(await getSiteSettings()).toEqual(siteSettings);
+  });
+
+  it('case studies', async () => {
+    for (const cs of caseStudies) {
+      expect(await getCaseStudy(cs.projectSlug)).toEqual(cs);
+    }
+    expect(await getCaseStudy('no-such-slug')).toBeNull();
+  });
+
+  it('project lookup by slug', async () => {
+    const p = projects[0];
+    expect(await getProjectBySlug(p.slug)).toEqual({ ...p, underExam: p.underExam ?? false });
+    expect(await getProjectBySlug('no-such-slug')).toBeNull();
   });
 });

--- a/jamesduxbury/tests/site-meta.test.ts
+++ b/jamesduxbury/tests/site-meta.test.ts
@@ -21,11 +21,12 @@ describe('site config', () => {
 });
 
 describe('sitemap and robots', () => {
-  it('covers every public route with no double slashes', async () => {
+  it('covers every public route and case study with no double slashes', async () => {
     const { default: sitemap } = await import('../src/app/sitemap');
     const { SITE_ROUTES } = await import('../src/lib/site');
-    const entries = sitemap();
-    expect(entries).toHaveLength(SITE_ROUTES.length);
+    const entries = await sitemap();
+    expect(entries.length).toBeGreaterThanOrEqual(SITE_ROUTES.length);
+    expect(entries.some((e) => e.url.endsWith('/work/researcher-agent'))).toBe(true);
     for (const e of entries) {
       expect(e.url).not.toMatch(/[^:]\/\//);
     }


### PR DESCRIPTION
Closes #8

Every project gets a case-study page at /work/[slug], DB-backed and editable from the admin console.

- `case_studies` table (migration 0003), one optional study per project keyed by `project_slug` with prose stored as paragraph runs. Deleting a project with a study is blocked by the FK until the study is deleted, which keeps the blob cleanup invariant.
- `prose` field type in the admin kit: markup textarea with bold/italic toolbar buttons and a live preview rendered by the same `renderRun` the public page uses.
- /work/[slug]: hero with status chip and tech stack, problem/approach/outcome sections, MetricBar reuse, repo/live CTAs, loading skeleton, per-slug OG image, sitemap entries. Projects without a study render their highlights with an under-examination or in-preparation notice.
- Seeded studies for researcher-agent and a new jamesduxbury-dot-com project row, per the agreed scope; content is editable at /admin/case-studies.
- Round-trip seed tests are now subset assertions keyed by slug/name, so a branch seeding new content can no longer fail main's CI against the shared dev DB (the cause of the red main run after #32).

Deviation from the issue text: the issue predates the v2 rebuild and specified build-time MDX read from src/data. Content is DB-backed and admin-edited now, so prose runs replace MDX (no new dependencies) and `generateStaticParams` reads the DB. Per-slug OG images and the static-export check are as specified: the build pre-renders all six pages.

227 tests, coverage thresholds enforced, full gate green.