### PR TITLE
feat(analytics): visit-flow visualisation in admin

### DIFF
--- a/jamesduxbury/src/admin/actions.ts
+++ b/jamesduxbury/src/admin/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { auth, isAdminSession } from '@/auth';
-import { getSql } from '@/db';
+import { markRead } from '@/db/messages';
 import { SITE_ROUTES } from '@/lib/site';
 import { parseFields, type FieldDef, type FieldValue } from './fields';
 import { deleteImage, imageFileError, uploadImage } from './images';
@@ -114,6 +114,6 @@ export async function deleteItem(slug: string, id: number): Promise<void> {
 
 export async function markMessageRead(id: number): Promise<void> {
   await requireAdmin();
-  await getSql()`UPDATE messages SET read = true WHERE id = ${id}`;
+  await markRead(id);
   revalidatePath('/admin/messages');
 }

--- a/jamesduxbury/src/app/admin/analytics/page.tsx
+++ b/jamesduxbury/src/app/admin/analytics/page.tsx
@@ -92,33 +92,34 @@ export default async function AnalyticsPage() {
         </div>
       </AdminPanel>
 
-      <AdminPanel title="visit flow" meta="last 30 days">
-        <div className="px-4 py-5 sm:px-6">
-          <VisitFlow transitions={transitions} />
-        </div>
-      </AdminPanel>
-
-      <AdminPanel title="entries, exits and drop-off" meta="last 30 days">
-        <div className="divide-y divide-border">
-          {flow.map((page) => (
-            <div
-              key={page.path}
-              className="flex items-baseline justify-between gap-4 px-4 py-3 sm:px-6"
-            >
-              <span className="truncate font-mono text-sm text-text">{page.path}</span>
-              <span className="whitespace-nowrap font-mono text-xs text-muted">
-                {page.steps} steps · {page.entries} in · {page.exits} out ·{' '}
-                {Math.round(page.dropOff * 100)}% drop-off
-              </span>
-            </div>
-          ))}
-          {flow.length === 0 && (
-            <p className="px-4 py-4 font-mono text-xs uppercase tracking-[0.18em] text-muted sm:px-6">
-              {`>`} no data yet
-            </p>
-          )}
-        </div>
-      </AdminPanel>
+      <div className="grid gap-x-6 lg:grid-cols-2">
+        <AdminPanel title="visit flow" meta="last 30 days">
+          <div className="px-4 py-5 sm:px-6">
+            <VisitFlow transitions={transitions} />
+          </div>
+        </AdminPanel>
+        <AdminPanel title="entries, exits and drop-off" meta="last 30 days">
+          <div className="divide-y divide-border">
+            {flow.map((page) => (
+              <div
+                key={page.path}
+                className="flex items-baseline justify-between gap-4 px-4 py-3 sm:px-6"
+              >
+                <span className="truncate font-mono text-sm text-text">{page.path}</span>
+                <span className="whitespace-nowrap font-mono text-xs text-muted">
+                  {page.steps} steps · {page.entries} in · {page.exits} out ·{' '}
+                  {Math.round(page.dropOff * 100)}% drop-off
+                </span>
+              </div>
+            ))}
+            {flow.length === 0 && (
+              <p className="px-4 py-4 font-mono text-xs uppercase tracking-[0.18em] text-muted sm:px-6">
+                {`>`} no data yet
+              </p>
+            )}
+          </div>
+        </AdminPanel>
+      </div>
 
       <div className="grid gap-x-6 lg:grid-cols-2">
         <AdminPanel title="top pages" meta="last 30 days">

--- a/jamesduxbury/src/app/admin/analytics/page.tsx
+++ b/jamesduxbury/src/app/admin/analytics/page.tsx
@@ -107,7 +107,7 @@ export default async function AnalyticsPage() {
             >
               <span className="truncate font-mono text-sm text-text">{page.path}</span>
               <span className="whitespace-nowrap font-mono text-xs text-muted">
-                {page.views} views · {page.entries} in · {page.exits} out ·{' '}
+                {page.steps} steps · {page.entries} in · {page.exits} out ·{' '}
                 {Math.round(page.dropOff * 100)}% drop-off
               </span>
             </div>

--- a/jamesduxbury/src/app/admin/analytics/page.tsx
+++ b/jamesduxbury/src/app/admin/analytics/page.tsx
@@ -1,5 +1,7 @@
 import {
   getAvgDurations,
+  getFlowPages,
+  getPageTransitions,
   getRecentSessions,
   getTopCountries,
   getTopPaths,
@@ -8,6 +10,7 @@ import {
   getVisitTotals,
 } from '@/db/analytics';
 import { AdminPanel } from '@/components/admin/AdminPanel';
+import { VisitFlow } from '@/components/admin/VisitFlow';
 
 function formatDuration(ms: number): string {
   const seconds = Math.round(ms / 1000);
@@ -41,15 +44,18 @@ function CountList({ rows }: { rows: { label: string; views: number }[] }) {
 }
 
 export default async function AnalyticsPage() {
-  const [totals, perDay, topPaths, referrers, countries, durations, sessions] = await Promise.all([
-    getVisitTotals(),
-    getViewsPerDay(30),
-    getTopPaths(30),
-    getTopReferrers(30),
-    getTopCountries(30),
-    getAvgDurations(30),
-    getRecentSessions(12),
-  ]);
+  const [totals, perDay, topPaths, referrers, countries, durations, sessions, transitions, flow] =
+    await Promise.all([
+      getVisitTotals(),
+      getViewsPerDay(30),
+      getTopPaths(30),
+      getTopReferrers(30),
+      getTopCountries(30),
+      getAvgDurations(30),
+      getRecentSessions(12),
+      getPageTransitions(30),
+      getFlowPages(30),
+    ]);
 
   const maxDay = Math.max(...perDay.map((d) => d.views), 1);
   const totalCards = [
@@ -83,6 +89,34 @@ export default async function AnalyticsPage() {
               style={{ height: `${Math.max((day.views / maxDay) * 100, day.views > 0 ? 4 : 1)}%` }}
             />
           ))}
+        </div>
+      </AdminPanel>
+
+      <AdminPanel title="visit flow" meta="last 30 days">
+        <div className="px-4 py-5 sm:px-6">
+          <VisitFlow transitions={transitions} />
+        </div>
+      </AdminPanel>
+
+      <AdminPanel title="entries, exits and drop-off" meta="last 30 days">
+        <div className="divide-y divide-border">
+          {flow.map((page) => (
+            <div
+              key={page.path}
+              className="flex items-baseline justify-between gap-4 px-4 py-3 sm:px-6"
+            >
+              <span className="truncate font-mono text-sm text-text">{page.path}</span>
+              <span className="whitespace-nowrap font-mono text-xs text-muted">
+                {page.views} views · {page.entries} in · {page.exits} out ·{' '}
+                {Math.round(page.dropOff * 100)}% drop-off
+              </span>
+            </div>
+          ))}
+          {flow.length === 0 && (
+            <p className="px-4 py-4 font-mono text-xs uppercase tracking-[0.18em] text-muted sm:px-6">
+              {`>`} no data yet
+            </p>
+          )}
         </div>
       </AdminPanel>
 

--- a/jamesduxbury/src/app/admin/messages/page.tsx
+++ b/jamesduxbury/src/app/admin/messages/page.tsx
@@ -1,22 +1,9 @@
 import { markMessageRead } from '@/admin/actions';
-import { getSql } from '@/db';
+import { getMessages } from '@/db/messages';
 import { AdminPanel } from '@/components/admin/AdminPanel';
 
-interface MessageRow {
-  id: number;
-  name: string;
-  email: string;
-  message: string;
-  read: boolean;
-  received_at: string;
-}
-
 export default async function MessagesPage() {
-  const rows = (await getSql()`
-    SELECT id, name, email, message, read,
-      to_char(created_at, 'YYYY-MM-DD HH24:MI') AS received_at
-    FROM messages ORDER BY created_at DESC
-  `) as MessageRow[];
+  const rows = await getMessages();
 
   const unread = rows.filter((row) => !row.read).length;
 
@@ -34,7 +21,7 @@ export default async function MessagesPage() {
                 {row.email}
               </a>
               <span className="ml-auto font-mono text-[0.65rem] text-muted/70">
-                {row.received_at}
+                {row.receivedAt}
               </span>
             </div>
             <p className="mt-3 whitespace-pre-wrap font-mono text-sm text-text/90">{row.message}</p>

--- a/jamesduxbury/src/app/api/contact/route.ts
+++ b/jamesduxbury/src/app/api/contact/route.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import nodemailer from 'nodemailer';
-import { getSql } from '@/db';
+import { insertMessage } from '@/db/messages';
 
 interface ContactPayload {
   name: string;
@@ -69,7 +69,7 @@ export async function POST(req: Request) {
   // Two delivery channels; the request only fails if both do
   let stored = false;
   try {
-    await getSql()`INSERT INTO messages (name, email, message) VALUES (${name}, ${email}, ${message})`;
+    await insertMessage(name, email, message);
     stored = true;
   } catch (error) {
     console.error(`[contact:${correlationId}] message insert failed`, error);

--- a/jamesduxbury/src/app/api/visit/route.ts
+++ b/jamesduxbury/src/app/api/visit/route.ts
@@ -1,9 +1,8 @@
-import { getSql } from '@/db';
+import { insertView, setViewDuration } from '@/db/visits';
 import { auth, isAdminSession } from '@/auth';
 
 const BOT_UA = /bot|crawl|spider|slurp|headless|preview|monitor|lighthouse/i;
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-const MAX_DURATION_MS = 6 * 60 * 60 * 1000;
 
 interface VisitPayload {
   sessionId?: unknown;
@@ -37,10 +36,7 @@ export async function POST(req: Request) {
     if (id === null || !Number.isFinite(durationMs) || durationMs < 0) {
       return Response.json({ error: 'Invalid payload' }, { status: 400 });
     }
-    await getSql()`
-      UPDATE page_views SET duration_ms = ${Math.min(durationMs, MAX_DURATION_MS)}
-      WHERE id = ${id}::bigint AND duration_ms IS NULL
-    `;
+    await setViewDuration(id, durationMs);
     return new Response(null, { status: 204 });
   }
 
@@ -55,10 +51,6 @@ export async function POST(req: Request) {
   // Public endpoint: the geo header is caller-controlled, so clamp it
   const countryHeader = req.headers.get('x-vercel-ip-country');
   const country = countryHeader && /^[A-Z]{2}$/.test(countryHeader) ? countryHeader : null;
-  const [row] = await getSql()`
-    INSERT INTO page_views (session_id, path, referrer, country)
-    VALUES (${sessionId}, ${path}, ${referrer}, ${country})
-    RETURNING id
-  `;
-  return Response.json({ id: String(row.id) });
+  const id = await insertView(sessionId, path, referrer, country);
+  return Response.json({ id });
 }

--- a/jamesduxbury/src/components/admin/VisitFlow.tsx
+++ b/jamesduxbury/src/components/admin/VisitFlow.tsx
@@ -1,7 +1,8 @@
 import type { PageTransition } from '@/db/analytics';
 
 const WIDTH = 640;
-const LABEL_W = 150;
+// fits 20 truncated characters of 14px mono plus the 8px gap to the node
+const LABEL_W = 180;
 const NODE_W = 6;
 const GAP = 10;
 const MIN_H = 14;
@@ -101,10 +102,10 @@ export function VisitFlow({ transitions }: { transitions: PageTransition[] }) {
           <rect x={LABEL_W} y={n.y} width={NODE_W} height={n.h} className="fill-accent" />
           <text
             x={LABEL_W - 8}
-            y={n.y + n.h / 2 + 4}
+            y={n.y + n.h / 2 + 5}
             textAnchor="end"
-            fontSize={11}
-            className="fill-muted font-mono"
+            fontSize={14}
+            className="fill-text font-mono"
           >
             {truncate(n.path)}
           </text>
@@ -121,9 +122,9 @@ export function VisitFlow({ transitions }: { transitions: PageTransition[] }) {
           />
           <text
             x={WIDTH - LABEL_W + 8}
-            y={n.y + n.h / 2 + 4}
-            fontSize={11}
-            className="fill-muted font-mono"
+            y={n.y + n.h / 2 + 5}
+            fontSize={14}
+            className="fill-text font-mono"
           >
             {truncate(n.path)}
           </text>

--- a/jamesduxbury/src/components/admin/VisitFlow.tsx
+++ b/jamesduxbury/src/components/admin/VisitFlow.tsx
@@ -9,20 +9,24 @@ const COLUMN_H = 200;
 
 interface Node {
   path: string;
-  total: number;
   y: number;
   h: number;
 }
 
-function stack(totals: Map<string, number>, scale: number): Map<string, Node> {
+// node heights sum their ribbons' floored widths so ribbons always fit inside
+function stack(heights: Map<string, number>): Map<string, Node> {
   const nodes = new Map<string, Node>();
   let y = 0;
-  for (const [path, total] of [...totals.entries()].sort((a, b) => b[1] - a[1])) {
-    const h = Math.max(total * scale, MIN_H);
-    nodes.set(path, { path, total, y, h });
+  for (const [path, sum] of [...heights.entries()].sort((a, b) => b[1] - a[1])) {
+    const h = Math.max(sum, MIN_H);
+    nodes.set(path, { path, y, h });
     y += h + GAP;
   }
   return nodes;
+}
+
+function truncate(path: string): string {
+  return path.length > 20 ? `${path.slice(0, 19)}…` : path;
 }
 
 function columnHeight(nodes: Map<string, Node>): number {
@@ -40,20 +44,19 @@ export function VisitFlow({ transitions }: { transitions: PageTransition[] }) {
     );
   }
 
-  const fromTotals = new Map<string, number>();
-  const toTotals = new Map<string, number>();
-  for (const t of transitions) {
-    fromTotals.set(t.from, (fromTotals.get(t.from) ?? 0) + t.count);
-    toTotals.set(t.to, (toTotals.get(t.to) ?? 0) + t.count);
-  }
-  const maxColumn = Math.max(
-    [...fromTotals.values()].reduce((a, b) => a + b, 0),
-    [...toTotals.values()].reduce((a, b) => a + b, 0),
-  );
-  const scale = COLUMN_H / maxColumn;
+  const totalCount = transitions.reduce((a, t) => a + t.count, 0);
+  const scale = COLUMN_H / totalCount;
+  const thicknessOf = (count: number) => Math.max(count * scale, 2);
 
-  const left = stack(fromTotals, scale);
-  const right = stack(toTotals, scale);
+  const fromHeights = new Map<string, number>();
+  const toHeights = new Map<string, number>();
+  for (const t of transitions) {
+    fromHeights.set(t.from, (fromHeights.get(t.from) ?? 0) + thicknessOf(t.count));
+    toHeights.set(t.to, (toHeights.get(t.to) ?? 0) + thicknessOf(t.count));
+  }
+
+  const left = stack(fromHeights);
+  const right = stack(toHeights);
   const height = Math.max(columnHeight(left), columnHeight(right));
 
   // ribbons leave each node in descending count order, tracked by running offsets
@@ -67,7 +70,7 @@ export function VisitFlow({ transitions }: { transitions: PageTransition[] }) {
     .map((t) => {
       const from = left.get(t.from)!;
       const to = right.get(t.to)!;
-      const thickness = Math.max(t.count * scale, 2);
+      const thickness = thicknessOf(t.count);
       const y1 = from.y + (leftOffset.get(t.from) ?? 0) + thickness / 2;
       const y2 = to.y + (rightOffset.get(t.to) ?? 0) + thickness / 2;
       leftOffset.set(t.from, (leftOffset.get(t.from) ?? 0) + thickness);
@@ -103,7 +106,7 @@ export function VisitFlow({ transitions }: { transitions: PageTransition[] }) {
             fontSize={11}
             className="fill-muted font-mono"
           >
-            {n.path}
+            {truncate(n.path)}
           </text>
         </g>
       ))}
@@ -122,7 +125,7 @@ export function VisitFlow({ transitions }: { transitions: PageTransition[] }) {
             fontSize={11}
             className="fill-muted font-mono"
           >
-            {n.path}
+            {truncate(n.path)}
           </text>
         </g>
       ))}

--- a/jamesduxbury/src/components/admin/VisitFlow.tsx
+++ b/jamesduxbury/src/components/admin/VisitFlow.tsx
@@ -1,0 +1,131 @@
+import type { PageTransition } from '@/db/analytics';
+
+const WIDTH = 640;
+const LABEL_W = 150;
+const NODE_W = 6;
+const GAP = 10;
+const MIN_H = 14;
+const COLUMN_H = 200;
+
+interface Node {
+  path: string;
+  total: number;
+  y: number;
+  h: number;
+}
+
+function stack(totals: Map<string, number>, scale: number): Map<string, Node> {
+  const nodes = new Map<string, Node>();
+  let y = 0;
+  for (const [path, total] of [...totals.entries()].sort((a, b) => b[1] - a[1])) {
+    const h = Math.max(total * scale, MIN_H);
+    nodes.set(path, { path, total, y, h });
+    y += h + GAP;
+  }
+  return nodes;
+}
+
+function columnHeight(nodes: Map<string, Node>): number {
+  let max = 0;
+  for (const n of nodes.values()) max = Math.max(max, n.y + n.h);
+  return max;
+}
+
+export function VisitFlow({ transitions }: { transitions: PageTransition[] }) {
+  if (transitions.length === 0) {
+    return (
+      <p className="font-mono text-xs uppercase tracking-[0.18em] text-muted">
+        {`>`} no multi-page sessions yet
+      </p>
+    );
+  }
+
+  const fromTotals = new Map<string, number>();
+  const toTotals = new Map<string, number>();
+  for (const t of transitions) {
+    fromTotals.set(t.from, (fromTotals.get(t.from) ?? 0) + t.count);
+    toTotals.set(t.to, (toTotals.get(t.to) ?? 0) + t.count);
+  }
+  const maxColumn = Math.max(
+    [...fromTotals.values()].reduce((a, b) => a + b, 0),
+    [...toTotals.values()].reduce((a, b) => a + b, 0),
+  );
+  const scale = COLUMN_H / maxColumn;
+
+  const left = stack(fromTotals, scale);
+  const right = stack(toTotals, scale);
+  const height = Math.max(columnHeight(left), columnHeight(right));
+
+  // ribbons leave each node in descending count order, tracked by running offsets
+  const leftOffset = new Map<string, number>();
+  const rightOffset = new Map<string, number>();
+  const x1 = LABEL_W + NODE_W;
+  const x2 = WIDTH - LABEL_W - NODE_W;
+  const midX = (x1 + x2) / 2;
+  const ribbons = [...transitions]
+    .sort((a, b) => b.count - a.count)
+    .map((t) => {
+      const from = left.get(t.from)!;
+      const to = right.get(t.to)!;
+      const thickness = Math.max(t.count * scale, 2);
+      const y1 = from.y + (leftOffset.get(t.from) ?? 0) + thickness / 2;
+      const y2 = to.y + (rightOffset.get(t.to) ?? 0) + thickness / 2;
+      leftOffset.set(t.from, (leftOffset.get(t.from) ?? 0) + thickness);
+      rightOffset.set(t.to, (rightOffset.get(t.to) ?? 0) + thickness);
+      return { ...t, thickness, d: `M ${x1} ${y1} C ${midX} ${y1}, ${midX} ${y2}, ${x2} ${y2}` };
+    });
+
+  return (
+    <svg
+      viewBox={`0 0 ${WIDTH} ${height}`}
+      className="w-full"
+      role="img"
+      aria-label="visit flow between pages"
+    >
+      {ribbons.map((r) => (
+        <path
+          key={`${r.from}-${r.to}`}
+          d={r.d}
+          fill="none"
+          strokeWidth={r.thickness}
+          className="stroke-accent/30"
+        >
+          <title>{`${r.from} → ${r.to} · ${r.count}`}</title>
+        </path>
+      ))}
+      {[...left.values()].map((n) => (
+        <g key={`from-${n.path}`}>
+          <rect x={LABEL_W} y={n.y} width={NODE_W} height={n.h} className="fill-accent" />
+          <text
+            x={LABEL_W - 8}
+            y={n.y + n.h / 2 + 4}
+            textAnchor="end"
+            fontSize={11}
+            className="fill-muted font-mono"
+          >
+            {n.path}
+          </text>
+        </g>
+      ))}
+      {[...right.values()].map((n) => (
+        <g key={`to-${n.path}`}>
+          <rect
+            x={WIDTH - LABEL_W - NODE_W}
+            y={n.y}
+            width={NODE_W}
+            height={n.h}
+            className="fill-accent"
+          />
+          <text
+            x={WIDTH - LABEL_W + 8}
+            y={n.y + n.h / 2 + 4}
+            fontSize={11}
+            className="fill-muted font-mono"
+          >
+            {n.path}
+          </text>
+        </g>
+      ))}
+    </svg>
+  );
+}

--- a/jamesduxbury/src/components/admin/VisitFlow.tsx
+++ b/jamesduxbury/src/components/admin/VisitFlow.tsx
@@ -87,7 +87,7 @@ export function VisitFlow({ transitions }: { transitions: PageTransition[] }) {
     >
       {ribbons.map((r) => (
         <path
-          key={`${r.from}-${r.to}`}
+          key={`${r.from} → ${r.to}`}
           d={r.d}
           fill="none"
           strokeWidth={r.thickness}

--- a/jamesduxbury/src/db/analytics.ts
+++ b/jamesduxbury/src/db/analytics.ts
@@ -145,7 +145,7 @@ export interface PageTransition {
 
 export interface FlowPage {
   path: string;
-  views: number;
+  steps: number;
   entries: number;
   exits: number;
   dropOff: number;
@@ -169,25 +169,35 @@ export async function getPageTransitions(days: number, limit = 12): Promise<Page
   return rows.map((r) => ({ from: r.from_path, to: r.to_path, count: r.count }));
 }
 
+// consecutive duplicate paths collapse to one step, matching the transitions query
 export async function getFlowPages(days: number, limit = 10): Promise<FlowPage[]> {
   const rows = (await getSql()`
     WITH ordered AS (
+      SELECT session_id, path, created_at, id,
+        lag(path) OVER (PARTITION BY session_id ORDER BY created_at, id) AS prev_raw
+      FROM page_views
+      WHERE created_at > now() - make_interval(days => ${days})
+    ),
+    deduped AS (
+      SELECT session_id, path, created_at, id FROM ordered
+      WHERE prev_raw IS NULL OR prev_raw <> path
+    ),
+    flow AS (
       SELECT path,
         lag(path) OVER (PARTITION BY session_id ORDER BY created_at, id) AS prev_path,
         lead(path) OVER (PARTITION BY session_id ORDER BY created_at, id) AS next_path
-      FROM page_views
-      WHERE created_at > now() - make_interval(days => ${days})
+      FROM deduped
     )
     SELECT path,
-      count(*)::int AS views,
+      count(*)::int AS steps,
       count(*) FILTER (WHERE prev_path IS NULL)::int AS entries,
       count(*) FILTER (WHERE next_path IS NULL)::int AS exits
-    FROM ordered
+    FROM flow
     GROUP BY path
-    ORDER BY views DESC, path
+    ORDER BY steps DESC, path
     LIMIT ${limit}
-  `) as { path: string; views: number; entries: number; exits: number }[];
-  return rows.map((r) => ({ ...r, dropOff: r.views > 0 ? r.exits / r.views : 0 }));
+  `) as { path: string; steps: number; entries: number; exits: number }[];
+  return rows.map((r) => ({ ...r, dropOff: r.steps > 0 ? r.exits / r.steps : 0 }));
 }
 
 export interface MessageCounts {

--- a/jamesduxbury/src/db/analytics.ts
+++ b/jamesduxbury/src/db/analytics.ts
@@ -137,6 +137,59 @@ export async function getRecentSessions(limit: number): Promise<RecentSession[]>
   }));
 }
 
+export interface PageTransition {
+  from: string;
+  to: string;
+  count: number;
+}
+
+export interface FlowPage {
+  path: string;
+  views: number;
+  entries: number;
+  exits: number;
+  dropOff: number;
+}
+
+export async function getPageTransitions(days: number, limit = 12): Promise<PageTransition[]> {
+  const rows = (await getSql()`
+    WITH ordered AS (
+      SELECT session_id, path,
+        lead(path) OVER (PARTITION BY session_id ORDER BY created_at, id) AS next_path
+      FROM page_views
+      WHERE created_at > now() - make_interval(days => ${days})
+    )
+    SELECT path AS from_path, next_path AS to_path, count(*)::int AS count
+    FROM ordered
+    WHERE next_path IS NOT NULL AND next_path <> path
+    GROUP BY path, next_path
+    ORDER BY count DESC, from_path, to_path
+    LIMIT ${limit}
+  `) as { from_path: string; to_path: string; count: number }[];
+  return rows.map((r) => ({ from: r.from_path, to: r.to_path, count: r.count }));
+}
+
+export async function getFlowPages(days: number, limit = 10): Promise<FlowPage[]> {
+  const rows = (await getSql()`
+    WITH ordered AS (
+      SELECT path,
+        lag(path) OVER (PARTITION BY session_id ORDER BY created_at, id) AS prev_path,
+        lead(path) OVER (PARTITION BY session_id ORDER BY created_at, id) AS next_path
+      FROM page_views
+      WHERE created_at > now() - make_interval(days => ${days})
+    )
+    SELECT path,
+      count(*)::int AS views,
+      count(*) FILTER (WHERE prev_path IS NULL)::int AS entries,
+      count(*) FILTER (WHERE next_path IS NULL)::int AS exits
+    FROM ordered
+    GROUP BY path
+    ORDER BY views DESC, path
+    LIMIT ${limit}
+  `) as { path: string; views: number; entries: number; exits: number }[];
+  return rows.map((r) => ({ ...r, dropOff: r.views > 0 ? r.exits / r.views : 0 }));
+}
+
 export interface MessageCounts {
   total: number;
   unread: number;

--- a/jamesduxbury/src/db/messages.ts
+++ b/jamesduxbury/src/db/messages.ts
@@ -1,0 +1,43 @@
+import { getSql } from '@/db';
+
+export interface Message {
+  id: number;
+  name: string;
+  email: string;
+  message: string;
+  read: boolean;
+  receivedAt: string;
+}
+
+interface MessageRow {
+  id: number;
+  name: string;
+  email: string;
+  message: string;
+  read: boolean;
+  received_at: string;
+}
+
+export async function getMessages(): Promise<Message[]> {
+  const rows = (await getSql()`
+    SELECT id, name, email, message, read,
+      to_char(created_at, 'YYYY-MM-DD HH24:MI') AS received_at
+    FROM messages ORDER BY created_at DESC
+  `) as MessageRow[];
+  return rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    email: r.email,
+    message: r.message,
+    read: r.read,
+    receivedAt: r.received_at,
+  }));
+}
+
+export async function insertMessage(name: string, email: string, message: string): Promise<void> {
+  await getSql()`INSERT INTO messages (name, email, message) VALUES (${name}, ${email}, ${message})`;
+}
+
+export async function markRead(id: number): Promise<void> {
+  await getSql()`UPDATE messages SET read = true WHERE id = ${id}`;
+}

--- a/jamesduxbury/src/db/visits.ts
+++ b/jamesduxbury/src/db/visits.ts
@@ -1,0 +1,25 @@
+import { getSql } from '@/db';
+
+const MAX_DURATION_MS = 6 * 60 * 60 * 1000;
+
+export async function insertView(
+  sessionId: string,
+  path: string,
+  referrer: string | null,
+  country: string | null,
+): Promise<string> {
+  const [row] = (await getSql()`
+    INSERT INTO page_views (session_id, path, referrer, country)
+    VALUES (${sessionId}, ${path}, ${referrer}, ${country})
+    RETURNING id
+  `) as { id: string | number }[];
+  return String(row.id);
+}
+
+// duration is written once by the exit beacon; later beacons must not extend it
+export async function setViewDuration(id: string, durationMs: number): Promise<void> {
+  await getSql()`
+    UPDATE page_views SET duration_ms = ${Math.min(durationMs, MAX_DURATION_MS)}
+    WHERE id = ${id}::bigint AND duration_ms IS NULL
+  `;
+}

--- a/jamesduxbury/tests/db-analytics.test.ts
+++ b/jamesduxbury/tests/db-analytics.test.ts
@@ -106,18 +106,19 @@ describe('analytics queries', () => {
     expect(ba?.count).toBe(1);
   });
 
-  it('derives entries, exits and drop-off per page', async () => {
+  it('derives entries, exits and drop-off per page with duplicates collapsed', async () => {
     const pages = await getFlowPages(30, 500);
+    // session A,B,A,A,A collapses to A,B,A
     expect(pages.find((p) => p.path === pathA)).toEqual({
       path: pathA,
-      views: 4,
+      steps: 2,
       entries: 1,
       exits: 1,
-      dropOff: 0.25,
+      dropOff: 0.5,
     });
     expect(pages.find((p) => p.path === pathB)).toEqual({
       path: pathB,
-      views: 2,
+      steps: 2,
       entries: 1,
       exits: 1,
       dropOff: 0.5,

--- a/jamesduxbury/tests/db-analytics.test.ts
+++ b/jamesduxbury/tests/db-analytics.test.ts
@@ -3,7 +3,9 @@ import { neon } from '@neondatabase/serverless';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
   getAvgDurations,
+  getFlowPages,
   getMessageCounts,
+  getPageTransitions,
   getRecentSessions,
   getTopCountries,
   getTopPaths,
@@ -14,6 +16,7 @@ import {
 
 const sql = neon(process.env.DATABASE_URL!);
 const sessionId = randomUUID();
+const bounceSessionId = randomUUID();
 const pathA = `/test-analytics-a-${Date.now()}`;
 const pathB = `/test-analytics-b-${Date.now()}`;
 
@@ -33,10 +36,15 @@ beforeAll(async () => {
         ${row.duration}, now() - make_interval(mins => ${row.minutesAgo}))
     `;
   }
+  // a single-view session: entry and exit on pathB
+  await sql`
+    INSERT INTO page_views (session_id, path, created_at)
+    VALUES (${bounceSessionId}, ${pathB}, now() - make_interval(mins => 6))
+  `;
 });
 
 afterAll(async () => {
-  await sql`DELETE FROM page_views WHERE session_id = ${sessionId}`;
+  await sql`DELETE FROM page_views WHERE session_id IN (${sessionId}, ${bounceSessionId})`;
 });
 
 describe('analytics queries', () => {
@@ -88,6 +96,32 @@ describe('analytics queries', () => {
     expect(ours?.country).toBe('ZZ');
     expect(ours?.totalMs).toBe(60_000);
     expect(ours?.startedAt).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/);
+  });
+
+  it('derives transitions between pages', async () => {
+    const transitions = await getPageTransitions(30, 500);
+    const ab = transitions.find((t) => t.from === pathA && t.to === pathB);
+    const ba = transitions.find((t) => t.from === pathB && t.to === pathA);
+    expect(ab?.count).toBe(1);
+    expect(ba?.count).toBe(1);
+  });
+
+  it('derives entries, exits and drop-off per page', async () => {
+    const pages = await getFlowPages(30, 500);
+    expect(pages.find((p) => p.path === pathA)).toEqual({
+      path: pathA,
+      views: 4,
+      entries: 1,
+      exits: 1,
+      dropOff: 0.25,
+    });
+    expect(pages.find((p) => p.path === pathB)).toEqual({
+      path: pathB,
+      views: 2,
+      entries: 1,
+      exits: 1,
+      dropOff: 0.5,
+    });
   });
 
   it('counts messages without negative or impossible values', async () => {

--- a/jamesduxbury/tests/db-messages.test.ts
+++ b/jamesduxbury/tests/db-messages.test.ts
@@ -1,0 +1,27 @@
+import { neon } from '@neondatabase/serverless';
+import { afterAll, describe, expect, it } from 'vitest';
+import { getMessages, insertMessage, markRead } from '../src/db/messages';
+
+const sql = neon(process.env.DATABASE_URL!);
+const emailMarker = 'db-messages-test@example.com';
+
+afterAll(async () => {
+  await sql`DELETE FROM messages WHERE email = ${emailMarker}`;
+});
+
+describe('messages module', () => {
+  it('round-trips a message through insert, list and markRead', async () => {
+    await insertMessage('Test', emailMarker, 'hello from db-messages test');
+
+    const inserted = (await getMessages()).find((m) => m.email === emailMarker);
+    expect(inserted).toBeDefined();
+    expect(inserted!.name).toBe('Test');
+    expect(inserted!.message).toBe('hello from db-messages test');
+    expect(inserted!.read).toBe(false);
+    expect(inserted!.receivedAt).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/);
+
+    await markRead(inserted!.id);
+    const after = (await getMessages()).find((m) => m.id === inserted!.id);
+    expect(after!.read).toBe(true);
+  });
+});

--- a/jamesduxbury/tests/visit-flow.dom.test.tsx
+++ b/jamesduxbury/tests/visit-flow.dom.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { VisitFlow } from '../src/components/admin/VisitFlow';
+
+const transitions = [
+  { from: '/', to: '/work', count: 6 },
+  { from: '/', to: '/about', count: 2 },
+  { from: '/work', to: '/contact', count: 1 },
+];
+
+describe('VisitFlow', () => {
+  it('renders a ribbon per transition with proportional widths', () => {
+    const { container } = render(<VisitFlow transitions={transitions} />);
+    const ribbons = container.querySelectorAll('path');
+    expect(ribbons).toHaveLength(3);
+    const widths = [...ribbons].map((p) => Number(p.getAttribute('stroke-width')));
+    expect(widths[0]).toBeGreaterThan(widths[1]);
+    expect(widths[1]).toBeGreaterThan(widths[2]);
+    expect(container.querySelector('svg')).toHaveAttribute(
+      'aria-label',
+      'visit flow between pages',
+    );
+  });
+
+  it('labels every source and target page', () => {
+    const { container } = render(<VisitFlow transitions={transitions} />);
+    const labels = [...container.querySelectorAll('text')].map((t) => t.textContent);
+    expect(labels).toContain('/');
+    expect(labels).toContain('/work');
+    expect(labels).toContain('/about');
+    expect(labels).toContain('/contact');
+  });
+
+  it('renders an empty state without transitions', () => {
+    render(<VisitFlow transitions={[]} />);
+    expect(screen.getByText(/no multi-page sessions yet/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #18

Two new dashboard panels built on the existing page_views data, no new collection and no chart dependency.

- `visit flow`: a server-rendered SVG flow diagram of navigation between pages. Sources on the left, destinations on the right, ribbon width proportional to transition count, tooltips with exact counts. Node heights sum their ribbons' widths so the geometry always fits; long paths truncate.
- `entries, exits and drop-off`: per page, how many sessions entered there, exited there, and the exit share per step.
- Queries use window functions over per-session sequences, ordered identically to the recent-sessions list. Consecutive duplicate paths (refreshes) collapse to one step in both queries, so all panels agree on what a transition is; the metric is named steps to keep it distinct from raw views.
- Query limits are parameterised so the integration tests assert deterministic fixtures regardless of real data volume.

232 tests, full gate green.