### PR TITLE
feat(site): /architecture page

### DIFF
--- a/.github/workflows/seed-production.yaml
+++ b/.github/workflows/seed-production.yaml
@@ -1,0 +1,41 @@
+name: Seed production
+
+# One-off: seeds the /architecture content into the production database on merge.
+# The seed is insert-if-missing, so re-runs on later main pushes cannot overwrite
+# console edits. A follow-up PR removes this workflow once the run is green.
+
+on:
+  push:
+    branches: [main]
+
+defaults:
+  run:
+    working-directory: jamesduxbury
+
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: jamesduxbury/package-lock.json
+
+      - name: Cache node_modules
+        id: modules-cache
+        uses: actions/cache@v4
+        with:
+          path: jamesduxbury/node_modules
+          key: ${{ runner.os }}-node20-modules-${{ hashFiles('jamesduxbury/package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.modules-cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Migrate and seed production
+        run: npm run db:migrate && npm run db:seed
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_MAIN }}

--- a/.github/workflows/seed-production.yaml
+++ b/.github/workflows/seed-production.yaml
@@ -1,8 +1,6 @@
 name: Seed production
 
-# One-off: seeds the /architecture content into the production database on merge.
-# The seed is insert-if-missing, so re-runs on later main pushes cannot overwrite
-# console edits. A follow-up PR removes this workflow once the run is green.
+# One-off insert-if-missing prod seed on merge; a follow-up PR removes it once green.
 
 on:
   push:
@@ -14,6 +12,10 @@ defaults:
 
 jobs:
   seed:
+    # serialise runs so back-to-back merges never migrate prod concurrently
+    concurrency:
+      group: seed-production
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The admin console:
 
 ### No ORM
 
-The schema is ten tables and the queries are straightforward. The Neon driver parameterises every tagged-template value, so the usual injection argument for an ORM does not apply, and the whole data layer stays readable in two files. Working directly with SQL was also part of the point of the project.
+The schema is eleven tables and the queries are straightforward. The Neon driver parameterises every tagged-template value, so the usual injection argument for an ORM does not apply, and the whole data layer stays readable in two files. Working directly with SQL was also part of the point of the project.
 
 ### A single-user allowlist instead of roles
 
@@ -166,6 +166,7 @@ The dashboard chart is a server-rendered bar chart built from divs. It is one de
 |---|---|
 | `projects`, `experience`, `education`, `certifications`, `skill_groups`, `about_paragraphs` | Site content, one table per section, ordered by an integer `sort_order` |
 | `case_studies` | One optional case study per project, keyed by project slug |
+| `architecture_sections` | Content for the /architecture page (intro, stack line, decision cards, build notes) |
 | `site_settings` | Single row of site-wide settings (currently the profile picture) |
 | `messages` | Contact form submissions |
 | `page_views` | Analytics events |

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The admin console:
 
 ### No ORM
 
-The schema is nine tables and the queries are straightforward. The Neon driver parameterises every tagged-template value, so the usual injection argument for an ORM does not apply, and the whole data layer stays readable in two files. Working directly with SQL was also part of the point of the project.
+The schema is ten tables and the queries are straightforward. The Neon driver parameterises every tagged-template value, so the usual injection argument for an ORM does not apply, and the whole data layer stays readable in two files. Working directly with SQL was also part of the point of the project.
 
 ### A single-user allowlist instead of roles
 
@@ -165,6 +165,7 @@ The dashboard chart is a server-rendered bar chart built from divs. It is one de
 | Table | Contents |
 |---|---|
 | `projects`, `experience`, `education`, `certifications`, `skill_groups`, `about_paragraphs` | Site content, one table per section, ordered by an integer `sort_order` |
+| `case_studies` | One optional case study per project, keyed by project slug |
 | `site_settings` | Single row of site-wide settings (currently the profile picture) |
 | `messages` | Contact form submissions |
 | `page_views` | Analytics events |

--- a/jamesduxbury/src/admin/sections.ts
+++ b/jamesduxbury/src/admin/sections.ts
@@ -235,6 +235,30 @@ export const SECTIONS: SectionConfig[] = [
     listLabel: (row) => String(row.project_slug),
   },
   {
+    slug: 'architecture',
+    table: 'architecture_sections',
+    title: 'Architecture',
+    fields: [
+      {
+        column: 'kind',
+        label: 'Kind',
+        type: 'select',
+        options: ['intro', 'stack', 'decision', 'build'],
+        help: 'where on the page the section renders',
+      },
+      { column: 'title', label: 'Title', type: 'text', help: 'shown on decision cards only' },
+      { column: 'body', label: 'Body', type: 'prose', help: proseHelp },
+      { column: 'sort_order', label: 'Sort order', type: 'sort_order' },
+    ],
+    schema: z.object({
+      kind: z.enum(['intro', 'stack', 'decision', 'build']),
+      title: z.string().min(1).nullable(),
+      body: proseSchema,
+      sort_order: sortOrder,
+    }),
+    listLabel: (row) => (row.title ? String(row.title) : String(row.kind)),
+  },
+  {
     slug: 'site',
     table: 'site_settings',
     title: 'Site',

--- a/jamesduxbury/src/app/architecture/loading.tsx
+++ b/jamesduxbury/src/app/architecture/loading.tsx
@@ -1,0 +1,24 @@
+import { SkeletonBits, SkeletonLine } from '@/components/skeleton/Skeleton';
+import { SkeletonShell } from '@/components/skeleton/SkeletonShell';
+
+export default function ArchitectureLoading() {
+  return (
+    <SkeletonShell
+      channel="07"
+      label="ARCHITECTURE"
+      ariaLabel="Loading architecture"
+      widthClass="max-w-5xl"
+    >
+      <div className="space-y-3 px-4 py-6 sm:px-6">
+        <SkeletonLine length={48} textClassName="text-sm" cursor />
+        <SkeletonLine length={40} textClassName="text-sm" />
+        <SkeletonBits length={28} className="text-xs" />
+      </div>
+      <div className="space-y-3 border-t border-border px-4 py-6 sm:px-6">
+        <SkeletonBits length={6} className="text-xs" />
+        <SkeletonLine length={44} textClassName="text-sm" />
+        <SkeletonLine length={44} textClassName="text-sm" />
+      </div>
+    </SkeletonShell>
+  );
+}

--- a/jamesduxbury/src/app/architecture/page.tsx
+++ b/jamesduxbury/src/app/architecture/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next';
+import { PageShell } from '@/components/PageShell';
+import { ArchitectureDetail } from '@/components/architecture/ArchitectureDetail';
+
+export const metadata: Metadata = {
+  title: 'Architecture · James Duxbury',
+  description:
+    'How this site is built: Next.js 15, Neon Postgres with raw SQL, a schema-driven admin console, and first-party analytics.',
+};
+
+export default function ArchitecturePage() {
+  return (
+    <PageShell widthClass="max-w-5xl">
+      <ArchitectureDetail />
+    </PageShell>
+  );
+}

--- a/jamesduxbury/src/app/architecture/page.tsx
+++ b/jamesduxbury/src/app/architecture/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next';
 import { PageShell } from '@/components/PageShell';
 import { ArchitectureDetail } from '@/components/architecture/ArchitectureDetail';
 
+export const revalidate = 60;
+
 export const metadata: Metadata = {
   title: 'Architecture · James Duxbury',
   description:

--- a/jamesduxbury/src/components/architecture/ArchDiagram.tsx
+++ b/jamesduxbury/src/components/architecture/ArchDiagram.tsx
@@ -1,61 +1,314 @@
-const lane = 'border border-border bg-surface/40 px-4 py-4 backdrop-blur-sm sm:px-6';
-const laneLabel = 'font-mono text-[0.65rem] uppercase tracking-[0.2em] text-muted';
-const box = 'border border-border bg-bg px-3 py-2 font-mono text-xs text-text/85 whitespace-nowrap';
-const arrow = 'py-1 text-center font-mono text-sm text-accent';
+'use client';
 
-function Lane({ label, items }: { label: string; items: string[] }) {
-  return (
-    <div className={lane}>
-      <p className={laneLabel}>{label}</p>
-      <div className="mt-3 flex flex-wrap gap-2">
-        {items.map((item) => (
-          <span key={item} className={box}>
-            {item}
-          </span>
-        ))}
-      </div>
-    </div>
-  );
+import { useState } from 'react';
+
+const W = 720;
+const NODE_W = 104;
+const NODE_H = 32;
+const col = (c: number) => 8 + c * 118;
+
+interface DiagramNode {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+  w?: number;
+  desc: string;
+}
+
+const NODES: DiagramNode[] = [
+  {
+    id: 'pages',
+    label: 'public pages',
+    x: col(0),
+    y: 34,
+    desc: 'server-rendered pages, statically cached by ISR',
+  },
+  {
+    id: 'beacon',
+    label: 'visit beacon',
+    x: col(1),
+    y: 34,
+    desc: 'posts one view per page; an exit beacon adds the duration',
+  },
+  { id: 'form', label: 'contact form', x: col(2), y: 34, desc: 'sends a message from /contact' },
+  {
+    id: 'routes',
+    label: 'public routes',
+    x: col(0),
+    y: 148,
+    desc: 'read content from Postgres; revalidated every 60s and on admin save',
+  },
+  {
+    id: 'visit',
+    label: '/api/visit',
+    x: col(1),
+    y: 148,
+    desc: 'records anonymous views; bots and the signed-in admin are skipped',
+  },
+  {
+    id: 'contact',
+    label: '/api/contact',
+    x: col(2),
+    y: 148,
+    desc: 'stores the message and emails it; fails only if both channels fail',
+  },
+  {
+    id: 'admin',
+    label: 'admin console',
+    x: col(4),
+    y: 122,
+    desc: 'schema-driven console behind the GitHub allowlist; each section is config',
+  },
+  {
+    id: 'actions',
+    label: 'server actions',
+    x: col(4),
+    y: 174,
+    desc: 'authz-checked writes to Postgres; saves revalidate every public route',
+  },
+  {
+    id: 'auth',
+    label: 'next-auth',
+    x: col(5),
+    y: 174,
+    desc: 'JWT sessions; only the jsduxie GitHub login is allowed in',
+  },
+  {
+    id: 'content',
+    label: 'content tables',
+    x: col(0),
+    y: 270,
+    desc: 'one table per content section, ordered by sort_order',
+  },
+  {
+    id: 'views',
+    label: 'page_views',
+    x: col(1),
+    y: 270,
+    desc: 'session id, path, referrer, country and duration; no cookies or IPs',
+  },
+  {
+    id: 'messages',
+    label: 'messages',
+    x: col(2),
+    y: 270,
+    desc: 'contact submissions, read in the admin inbox',
+  },
+  {
+    id: 'email',
+    label: 'email',
+    x: 375,
+    y: 270,
+    desc: 'nodemailer delivery of contact messages',
+  },
+  {
+    id: 'blob',
+    label: 'vercel blob',
+    x: 490,
+    y: 270,
+    desc: 'images uploaded from the console, served from the CDN',
+  },
+  { id: 'oauth', label: 'github oauth', x: 605, y: 270, desc: 'one OAuth app per environment' },
+  {
+    id: 'ci',
+    label: 'github actions · checks',
+    x: col(0),
+    y: 358,
+    w: 222,
+    desc: 'format, lint, typecheck and coverage-gated tests on every PR',
+  },
+  {
+    id: 'deploy',
+    label: 'vercel build · migrate',
+    x: col(2),
+    y: 358,
+    w: 222,
+    desc: 'every deploy migrates its target database before next build runs',
+  },
+];
+
+const EDGES: [string, string][] = [
+  ['pages', 'routes'],
+  ['beacon', 'visit'],
+  ['form', 'contact'],
+  ['routes', 'content'],
+  ['visit', 'views'],
+  ['contact', 'messages'],
+  ['contact', 'email'],
+  ['admin', 'actions'],
+  ['admin', 'auth'],
+  ['actions', 'content'],
+  ['actions', 'blob'],
+  ['auth', 'oauth'],
+];
+
+const LANES = [
+  { label: 'visitor browser', x: 0, w: W, y: 0, h: 76 },
+  { label: 'next.js on vercel', x: 0, w: W, y: 88, h: 130 },
+  { label: 'neon postgres', x: 0, w: 356, y: 236, h: 76 },
+  { label: 'external', x: 364, w: 356, y: 236, h: 76 },
+  { label: 'ci and deployment', x: 0, w: W, y: 324, h: 76 },
+];
+
+const H = 404;
+
+// long cross-column edges travel the corridor between lanes instead of sweeping diagonals;
+// xOff staggers an arrowhead so merged targets keep both edges visible
+const VIA: Record<string, { y: number; xOff?: number }> = {
+  'actions-content': { y: 230, xOff: 12 },
+  'contact-email': { y: 222 },
+};
+
+function edgePath([from, to]: [string, string]): string {
+  const a = NODES.find((n) => n.id === from)!;
+  const b = NODES.find((n) => n.id === to)!;
+  const x1 = a.x + (a.w ?? NODE_W) / 2;
+  const y1 = a.y + NODE_H;
+  const y2 = b.y - 3;
+  const via = VIA[`${from}-${to}`];
+  const x2 = b.x + (b.w ?? NODE_W) / 2 + (via?.xOff ?? 0);
+  if (via) {
+    const dir = x2 > x1 ? 1 : -1;
+    return [
+      `M ${x1} ${y1} L ${x1} ${via.y - 8}`,
+      `Q ${x1} ${via.y} ${x1 + 8 * dir} ${via.y}`,
+      `L ${x2 - 8 * dir} ${via.y}`,
+      `Q ${x2} ${via.y} ${x2} ${via.y + 8}`,
+      `L ${x2} ${y2}`,
+    ].join(' ');
+  }
+  return `M ${x1} ${y1} C ${x1} ${y1 + 26}, ${x2} ${y2 - 26}, ${x2} ${y2}`;
 }
 
 export function ArchDiagram() {
+  const [active, setActive] = useState<string | null>(null);
+
+  const linked = new Set(
+    active ? [active, ...EDGES.filter((e) => e.includes(active)).flat()] : NODES.map((n) => n.id),
+  );
+  const edgeOn = ([from, to]: [string, string]) => active === from || active === to;
+
   return (
     <div>
-      <Lane label="visitor browser" items={['public pages', 'visit beacon', 'contact form']} />
-      <p className={arrow} aria-hidden>
-        ↓
-      </p>
-      <Lane
-        label="next.js on vercel"
-        items={[
-          'public routes · ISR',
-          '/api/visit',
-          '/api/contact',
-          'admin console',
-          'server actions',
-          'next-auth',
-        ]}
-      />
-      <p className={arrow} aria-hidden>
-        ↓
-      </p>
-      <div className="grid gap-3 sm:grid-cols-2">
-        <Lane
-          label="neon postgres"
-          items={['content tables', 'page_views', 'messages', 'case_studies']}
-        />
-        <Lane label="external" items={['vercel blob', 'github oauth', 'email']} />
+      {/* scrolls instead of shrinking so labels stay legible on small screens */}
+      <div className="overflow-x-auto">
+        <svg
+          viewBox={`0 0 ${W} ${H}`}
+          className="w-full min-w-[640px]"
+          role="img"
+          aria-label="system diagram"
+        >
+          <defs>
+            <marker
+              id="arch-arrow"
+              viewBox="0 0 6 6"
+              refX="5"
+              refY="3"
+              markerWidth="6"
+              markerHeight="6"
+              orient="auto"
+            >
+              <path d="M 0 0 L 6 3 L 0 6 z" className="fill-muted" />
+            </marker>
+            <marker
+              id="arch-arrow-on"
+              viewBox="0 0 6 6"
+              refX="5"
+              refY="3"
+              markerWidth="6"
+              markerHeight="6"
+              orient="auto"
+            >
+              <path d="M 0 0 L 6 3 L 0 6 z" className="fill-accent" />
+            </marker>
+          </defs>
+
+          {LANES.map((lane) => (
+            <rect
+              key={lane.label}
+              x={lane.x + 0.5}
+              y={lane.y + 0.5}
+              width={lane.w - 1}
+              height={lane.h - 1}
+              className="fill-surface/40 stroke-border"
+            />
+          ))}
+
+          {EDGES.map((edge) => (
+            <path
+              key={edge.join('-')}
+              d={edgePath(edge)}
+              fill="none"
+              strokeWidth={edgeOn(edge) ? 1.5 : 1}
+              markerEnd={edgeOn(edge) ? 'url(#arch-arrow-on)' : 'url(#arch-arrow)'}
+              className={`transition-opacity ${edgeOn(edge) ? 'stroke-accent' : 'stroke-muted/60'} ${
+                active && !edgeOn(edge) ? 'opacity-25' : ''
+              }`}
+            />
+          ))}
+
+          {/* labels render above the edges on an opaque chip so lines never run through text */}
+          {LANES.map((lane) => (
+            <g key={lane.label}>
+              <rect
+                x={lane.x + 8}
+                y={lane.y + 7}
+                width={lane.label.length * 8 + 10}
+                height={15}
+                className="fill-bg"
+              />
+              <text
+                x={lane.x + 12}
+                y={lane.y + 18}
+                fontSize={10}
+                letterSpacing="0.2em"
+                className="fill-muted font-mono uppercase"
+              >
+                {lane.label}
+              </text>
+            </g>
+          ))}
+
+          {NODES.map((n) => (
+            <g
+              key={n.id}
+              tabIndex={0}
+              onMouseEnter={() => setActive(n.id)}
+              onMouseLeave={() => setActive(null)}
+              onFocus={() => setActive(n.id)}
+              onBlur={() => setActive(null)}
+              className={`cursor-default outline-none transition-opacity ${
+                linked.has(n.id) ? '' : 'opacity-25'
+              }`}
+            >
+              <title>{n.desc}</title>
+              <rect
+                x={n.x + 0.5}
+                y={n.y + 0.5}
+                width={(n.w ?? NODE_W) - 1}
+                height={NODE_H - 1}
+                className={`fill-bg ${active === n.id ? 'stroke-accent' : 'stroke-border'}`}
+              />
+              <text
+                x={n.x + (n.w ?? NODE_W) / 2}
+                y={n.y + NODE_H / 2 + 4}
+                textAnchor="middle"
+                fontSize={11}
+                className={`font-mono ${active === n.id ? 'fill-text' : 'fill-text/85'}`}
+              >
+                {n.label}
+              </text>
+            </g>
+          ))}
+        </svg>
       </div>
-      <p className={arrow} aria-hidden>
-        ↓
+
+      <p className="mt-3 min-h-10 font-mono text-xs text-muted">
+        {active
+          ? `> ${NODES.find((n) => n.id === active)!.label}: ${NODES.find((n) => n.id === active)!.desc}`
+          : '> hover a component to trace its connections'}
       </p>
-      <Lane
-        label="ci and deployment"
-        items={[
-          'github actions: format, lint, typecheck, test',
-          'vercel build: migrate, then next build',
-        ]}
-      />
     </div>
   );
 }

--- a/jamesduxbury/src/components/architecture/ArchDiagram.tsx
+++ b/jamesduxbury/src/components/architecture/ArchDiagram.tsx
@@ -153,8 +153,7 @@ const LANES = [
 
 const H = 404;
 
-// long cross-column edges travel the corridor between lanes instead of sweeping diagonals;
-// xOff staggers an arrowhead so merged targets keep both edges visible
+// corridor-routed edges avoid diagonal sweeps; xOff keeps merged arrowheads apart
 const VIA: Record<string, { y: number; xOff?: number }> = {
   'actions-content': { y: 230, xOff: 12 },
   'contact-email': { y: 222 },

--- a/jamesduxbury/src/components/architecture/ArchDiagram.tsx
+++ b/jamesduxbury/src/components/architecture/ArchDiagram.tsx
@@ -20,7 +20,7 @@ function Lane({ label, items }: { label: string; items: string[] }) {
 
 export function ArchDiagram() {
   return (
-    <div aria-label="architecture diagram">
+    <div>
       <Lane label="visitor browser" items={['public pages', 'visit beacon', 'contact form']} />
       <p className={arrow} aria-hidden>
         ↓

--- a/jamesduxbury/src/components/architecture/ArchDiagram.tsx
+++ b/jamesduxbury/src/components/architecture/ArchDiagram.tsx
@@ -1,0 +1,61 @@
+const lane = 'border border-border bg-surface/40 px-4 py-4 backdrop-blur-sm sm:px-6';
+const laneLabel = 'font-mono text-[0.65rem] uppercase tracking-[0.2em] text-muted';
+const box = 'border border-border bg-bg px-3 py-2 font-mono text-xs text-text/85 whitespace-nowrap';
+const arrow = 'py-1 text-center font-mono text-sm text-accent';
+
+function Lane({ label, items }: { label: string; items: string[] }) {
+  return (
+    <div className={lane}>
+      <p className={laneLabel}>{label}</p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {items.map((item) => (
+          <span key={item} className={box}>
+            {item}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function ArchDiagram() {
+  return (
+    <div aria-label="architecture diagram">
+      <Lane label="visitor browser" items={['public pages', 'visit beacon', 'contact form']} />
+      <p className={arrow} aria-hidden>
+        ↓
+      </p>
+      <Lane
+        label="next.js on vercel"
+        items={[
+          'public routes · ISR',
+          '/api/visit',
+          '/api/contact',
+          'admin console',
+          'server actions',
+          'next-auth',
+        ]}
+      />
+      <p className={arrow} aria-hidden>
+        ↓
+      </p>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Lane
+          label="neon postgres"
+          items={['content tables', 'page_views', 'messages', 'case_studies']}
+        />
+        <Lane label="external" items={['vercel blob', 'github oauth', 'email']} />
+      </div>
+      <p className={arrow} aria-hidden>
+        ↓
+      </p>
+      <Lane
+        label="ci and deployment"
+        items={[
+          'github actions: format, lint, typecheck, test',
+          'vercel build: migrate, then next build',
+        ]}
+      />
+    </div>
+  );
+}

--- a/jamesduxbury/src/components/architecture/ArchitectureDetail.tsx
+++ b/jamesduxbury/src/components/architecture/ArchitectureDetail.tsx
@@ -1,50 +1,36 @@
 import { Widget } from '@/components/console/Widget';
+import { renderRun } from '@/components/about/renderRun';
+import { getArchitectureSections } from '@/db/queries';
+import type { ArchitectureSection } from '@/data/architecture';
 import { ArchDiagram } from './ArchDiagram';
 
-const DECISIONS: { title: string; body: string }[] = [
-  {
-    title: 'no ORM',
-    body: 'The schema is ten tables and the queries are straightforward. The Neon driver parameterises every tagged-template value, so the usual injection argument for an ORM does not apply, and the whole data layer stays readable in two files. Working directly with SQL was also part of the point of the project.',
-  },
-  {
-    title: 'a single-user allowlist instead of roles',
-    body: 'The site has exactly one editor. Checking my GitHub login by identity at every layer is simpler and stricter than a role system, and there is no user table to manage because sessions are JWTs.',
-  },
-  {
-    title: 'insert-if-missing seed',
-    body: 'The seed exists to boot an empty database and nothing else. It inserts with ON CONFLICT DO NOTHING, so running it against a populated database can never overwrite content edited through the console. Tests assert this property.',
-  },
-  {
-    title: 'ISR with revalidation on save',
-    body: 'Visitors get statically cached pages; the database is not touched per request. Saving in the admin console revalidates every public route, so edits appear immediately. This gets CDN speed without stale content.',
-  },
-  {
-    title: 'first-party analytics',
-    body: 'I want rough visit numbers, not a tracking product. Collecting a per-tab session id and no cookies, IPs or fingerprints keeps the data in my own database and keeps the site free of consent banners.',
-  },
-  {
-    title: 'images in Vercel Blob',
-    body: 'The images are a few megabytes in total, so almost anything would work. I evaluated Cloudflare R2 and Postgres bytea behind a cached route handler; Blob won because it needs no extra account or dependency and serves straight from the CDN. Old blobs are deleted when an image is replaced, so storage stays flat.',
-  },
-  {
-    title: 'no chart library',
-    body: 'The dashboard chart is a server-rendered bar chart built from divs. It is one dependency fewer and renders without client-side JavaScript.',
-  },
-];
+function Paragraphs({ sections }: { sections: ArchitectureSection[] }) {
+  return (
+    <>
+      {sections.map((s, i) =>
+        s.body.map((p, j) => (
+          <p key={`${i}-${j}`} className="text-sm leading-relaxed text-text/85 sm:text-base">
+            {p.map(renderRun)}
+          </p>
+        )),
+      )}
+    </>
+  );
+}
 
-export function ArchitectureDetail() {
+export async function ArchitectureDetail() {
+  const sections = await getArchitectureSections();
+  const byKind = (kind: ArchitectureSection['kind']) => sections.filter((s) => s.kind === kind);
+
   return (
     <Widget channel="07" label="ARCHITECTURE" id="architecture">
       <div className="space-y-4 px-4 py-6 sm:px-6">
-        <p className="text-sm leading-relaxed text-text/85 sm:text-base">
-          This site started as a static portfolio and is now a full-stack application. All content
-          lives in Postgres and is editable through an authenticated admin console, so the site
-          updates without a code push. Visits are tracked first-party and shown on an analytics
-          dashboard.
-        </p>
-        <p className="font-mono text-xs text-muted">
-          Next.js 15 · TypeScript · Tailwind CSS · Neon Postgres, raw SQL · next-auth · Vercel
-        </p>
+        <Paragraphs sections={byKind('intro')} />
+        {byKind('stack').map((s, i) => (
+          <p key={i} className="font-mono text-xs text-muted">
+            {s.body.flat().map(renderRun)}
+          </p>
+        ))}
       </div>
 
       <div className="border-t border-border px-4 py-6 sm:px-6">
@@ -59,26 +45,26 @@ export function ArchitectureDetail() {
           design decisions
         </h3>
         <div className="mt-4 grid gap-3 sm:grid-cols-2">
-          {DECISIONS.map((d) => (
-            <div key={d.title} className="border border-border bg-bg/40 px-4 py-4">
-              <h4 className="font-mono text-sm text-accent">{d.title}</h4>
-              <p className="mt-2 text-sm leading-relaxed text-text/85">{d.body}</p>
+          {byKind('decision').map((d, i) => (
+            <div key={d.title ?? i} className="border border-border bg-bg/40 px-4 py-4">
+              <h4 className="font-mono text-sm uppercase tracking-[0.15em] text-accent">
+                {d.title}
+              </h4>
+              {d.body.map((p, j) => (
+                <p key={j} className="mt-2 text-sm leading-relaxed text-text/85">
+                  {p.map(renderRun)}
+                </p>
+              ))}
             </div>
           ))}
         </div>
       </div>
 
-      <div className="border-t border-border px-4 py-6 sm:px-6">
+      <div className="space-y-3 border-t border-border px-4 py-6 sm:px-6">
         <h3 className="font-mono text-xs uppercase tracking-[0.2em] text-muted">
           how it was built
         </h3>
-        <p className="mt-3 text-sm leading-relaxed text-text/85 sm:text-base">
-          The rebuild was planned as GitHub issues grouped into milestones and shipped as small,
-          reviewed pull requests. Every change passes the same gate: formatting, lint, typecheck, a
-          test suite with enforced coverage thresholds running against a separate Neon branch, and a
-          production build. Deployments migrate their target database before building, so schema and
-          code always move together.
-        </p>
+        <Paragraphs sections={byKind('build')} />
       </div>
     </Widget>
   );

--- a/jamesduxbury/src/components/architecture/ArchitectureDetail.tsx
+++ b/jamesduxbury/src/components/architecture/ArchitectureDetail.tsx
@@ -1,0 +1,85 @@
+import { Widget } from '@/components/console/Widget';
+import { ArchDiagram } from './ArchDiagram';
+
+const DECISIONS: { title: string; body: string }[] = [
+  {
+    title: 'no ORM',
+    body: 'The schema is ten tables and the queries are straightforward. The Neon driver parameterises every tagged-template value, so the usual injection argument for an ORM does not apply, and the whole data layer stays readable in two files.',
+  },
+  {
+    title: 'a single-user allowlist instead of roles',
+    body: 'The site has exactly one editor. Checking my GitHub login by identity at every layer is simpler and stricter than a role system, and there is no user table to manage because sessions are JWTs.',
+  },
+  {
+    title: 'insert-if-missing seed',
+    body: 'The seed exists to boot an empty database and nothing else. It inserts with ON CONFLICT DO NOTHING, so running it against a populated database can never overwrite content edited through the console. Tests assert this property.',
+  },
+  {
+    title: 'ISR with revalidation on save',
+    body: 'Visitors get statically cached pages; the database is not touched per request. Saving in the admin console revalidates every public route, so edits appear immediately. This gets CDN speed without stale content.',
+  },
+  {
+    title: 'first-party analytics',
+    body: 'I want rough visit numbers, not a tracking product. Collecting a per-tab session id and no cookies, IPs or fingerprints keeps the data in my own database and keeps the site free of consent banners.',
+  },
+  {
+    title: 'images in Vercel Blob',
+    body: 'Site images are uploaded from the admin console and served from the CDN. Old blobs are deleted when an image is replaced or its row is deleted, so storage stays flat.',
+  },
+  {
+    title: 'no chart library',
+    body: 'The analytics dashboard is server-rendered: a div bar chart and an SVG flow diagram. That keeps chart dependencies out and renders without client-side JavaScript.',
+  },
+];
+
+export function ArchitectureDetail() {
+  return (
+    <Widget channel="07" label="ARCHITECTURE" id="architecture">
+      <div className="space-y-4 px-4 py-6 sm:px-6">
+        <p className="text-sm leading-relaxed text-text/85 sm:text-base">
+          This site started as a static portfolio and is now a full-stack application. All content
+          lives in Postgres and is editable through an authenticated admin console, so the site
+          updates without a code push. Visits are tracked first-party and shown on an analytics
+          dashboard.
+        </p>
+        <p className="font-mono text-xs text-muted">
+          Next.js 15 · TypeScript · Tailwind CSS · Neon Postgres, raw SQL · next-auth · Vercel
+        </p>
+      </div>
+
+      <div className="border-t border-border px-4 py-6 sm:px-6">
+        <h2 className="font-mono text-xs uppercase tracking-[0.2em] text-muted">system</h2>
+        <div className="mt-4">
+          <ArchDiagram />
+        </div>
+      </div>
+
+      <div className="border-t border-border px-4 py-6 sm:px-6">
+        <h2 className="font-mono text-xs uppercase tracking-[0.2em] text-muted">
+          design decisions
+        </h2>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          {DECISIONS.map((d) => (
+            <div key={d.title} className="border border-border bg-bg/40 px-4 py-4">
+              <h3 className="font-mono text-sm text-accent">{d.title}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-text/85">{d.body}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="border-t border-border px-4 py-6 sm:px-6">
+        <h2 className="font-mono text-xs uppercase tracking-[0.2em] text-muted">
+          how it was built
+        </h2>
+        <p className="mt-3 text-sm leading-relaxed text-text/85 sm:text-base">
+          The rebuild was planned as GitHub issues grouped into milestones and shipped as small,
+          reviewed pull requests. Every change passes the same gate: formatting, lint, typecheck, a
+          test suite with enforced coverage thresholds running against a separate Neon branch, and a
+          production build. Deployments migrate their target database before building, so schema and
+          code always move together.
+        </p>
+      </div>
+    </Widget>
+  );
+}

--- a/jamesduxbury/src/components/architecture/ArchitectureDetail.tsx
+++ b/jamesduxbury/src/components/architecture/ArchitectureDetail.tsx
@@ -4,7 +4,7 @@ import { ArchDiagram } from './ArchDiagram';
 const DECISIONS: { title: string; body: string }[] = [
   {
     title: 'no ORM',
-    body: 'The schema is ten tables and the queries are straightforward. The Neon driver parameterises every tagged-template value, so the usual injection argument for an ORM does not apply, and the whole data layer stays readable in two files.',
+    body: 'The schema is ten tables and the queries are straightforward. The Neon driver parameterises every tagged-template value, so the usual injection argument for an ORM does not apply, and the whole data layer stays readable in two files. Working directly with SQL was also part of the point of the project.',
   },
   {
     title: 'a single-user allowlist instead of roles',
@@ -24,11 +24,11 @@ const DECISIONS: { title: string; body: string }[] = [
   },
   {
     title: 'images in Vercel Blob',
-    body: 'Site images are uploaded from the admin console and served from the CDN. Old blobs are deleted when an image is replaced or its row is deleted, so storage stays flat.',
+    body: 'The images are a few megabytes in total, so almost anything would work. I evaluated Cloudflare R2 and Postgres bytea behind a cached route handler; Blob won because it needs no extra account or dependency and serves straight from the CDN. Old blobs are deleted when an image is replaced, so storage stays flat.',
   },
   {
     title: 'no chart library',
-    body: 'The analytics dashboard is server-rendered: a div bar chart and an SVG flow diagram. That keeps chart dependencies out and renders without client-side JavaScript.',
+    body: 'The dashboard chart is a server-rendered bar chart built from divs. It is one dependency fewer and renders without client-side JavaScript.',
   },
 ];
 
@@ -48,20 +48,20 @@ export function ArchitectureDetail() {
       </div>
 
       <div className="border-t border-border px-4 py-6 sm:px-6">
-        <h2 className="font-mono text-xs uppercase tracking-[0.2em] text-muted">system</h2>
+        <h3 className="font-mono text-xs uppercase tracking-[0.2em] text-muted">system</h3>
         <div className="mt-4">
           <ArchDiagram />
         </div>
       </div>
 
       <div className="border-t border-border px-4 py-6 sm:px-6">
-        <h2 className="font-mono text-xs uppercase tracking-[0.2em] text-muted">
+        <h3 className="font-mono text-xs uppercase tracking-[0.2em] text-muted">
           design decisions
-        </h2>
+        </h3>
         <div className="mt-4 grid gap-3 sm:grid-cols-2">
           {DECISIONS.map((d) => (
             <div key={d.title} className="border border-border bg-bg/40 px-4 py-4">
-              <h3 className="font-mono text-sm text-accent">{d.title}</h3>
+              <h4 className="font-mono text-sm text-accent">{d.title}</h4>
               <p className="mt-2 text-sm leading-relaxed text-text/85">{d.body}</p>
             </div>
           ))}
@@ -69,9 +69,9 @@ export function ArchitectureDetail() {
       </div>
 
       <div className="border-t border-border px-4 py-6 sm:px-6">
-        <h2 className="font-mono text-xs uppercase tracking-[0.2em] text-muted">
+        <h3 className="font-mono text-xs uppercase tracking-[0.2em] text-muted">
           how it was built
-        </h2>
+        </h3>
         <p className="mt-3 text-sm leading-relaxed text-text/85 sm:text-base">
           The rebuild was planned as GitHub issues grouped into milestones and shipped as small,
           reviewed pull requests. Every change passes the same gate: formatting, lint, typecheck, a

--- a/jamesduxbury/src/components/console/StatusBar.tsx
+++ b/jamesduxbury/src/components/console/StatusBar.tsx
@@ -10,6 +10,7 @@ const NAV_LINKS: { href: string; label: string }[] = [
   { href: '/skills', label: 'skills' },
   { href: '/experience', label: 'experience' },
   { href: '/education', label: 'education' },
+  { href: '/architecture', label: 'architecture' },
 ];
 
 const isActive = (pathname: string | null, href: string): boolean => {

--- a/jamesduxbury/src/data/architecture.ts
+++ b/jamesduxbury/src/data/architecture.ts
@@ -1,0 +1,97 @@
+import type { AboutParagraph } from './about';
+
+export type ArchitectureSectionKind = 'intro' | 'stack' | 'decision' | 'build';
+
+export interface ArchitectureSection {
+  kind: ArchitectureSectionKind;
+  title?: string;
+  body: AboutParagraph[];
+}
+
+export const architectureSections: ArchitectureSection[] = [
+  {
+    kind: 'intro',
+    body: [
+      [
+        'This site started as a static portfolio and is now a full-stack application. All content lives in Postgres and is editable through an authenticated admin console, so the site updates without a code push. Visits are tracked first-party and shown on an analytics dashboard.',
+      ],
+    ],
+  },
+  {
+    kind: 'stack',
+    body: [
+      ['Next.js 15 · TypeScript · Tailwind CSS · Neon Postgres, raw SQL · next-auth · Vercel'],
+    ],
+  },
+  {
+    kind: 'decision',
+    title: 'no ORM',
+    body: [
+      [
+        'The schema is eleven tables and the queries are straightforward. The Neon driver parameterises every tagged-template value, so the usual injection argument for an ORM does not apply, and the whole data layer stays readable in two files. Working directly with SQL was also part of the point of the project.',
+      ],
+    ],
+  },
+  {
+    kind: 'decision',
+    title: 'a single-user allowlist instead of roles',
+    body: [
+      [
+        'The site has exactly one editor. Checking my GitHub login by identity at every layer is simpler and stricter than a role system, and there is no user table to manage because sessions are JWTs.',
+      ],
+    ],
+  },
+  {
+    kind: 'decision',
+    title: 'insert-if-missing seed',
+    body: [
+      [
+        'The seed exists to boot an empty database and nothing else. It inserts with ON CONFLICT DO NOTHING, so running it against a populated database can never overwrite content edited through the console. Tests assert this property.',
+      ],
+    ],
+  },
+  {
+    kind: 'decision',
+    title: 'ISR with revalidation on save',
+    body: [
+      [
+        'Visitors get statically cached pages; the database is not touched per request. Saving in the admin console revalidates every public route, so edits appear immediately. This gets CDN speed without stale content.',
+      ],
+    ],
+  },
+  {
+    kind: 'decision',
+    title: 'first-party analytics',
+    body: [
+      [
+        'I want rough visit numbers, not a tracking product. Collecting a per-tab session id and no cookies, IPs or fingerprints keeps the data in my own database and keeps the site free of consent banners.',
+      ],
+    ],
+  },
+  {
+    kind: 'decision',
+    title: 'images in Vercel Blob',
+    body: [
+      [
+        'The images are a few megabytes in total, so almost anything would work. I evaluated Cloudflare R2 and Postgres bytea behind a cached route handler; Blob won because it needs no extra account or dependency and serves straight from the CDN. Old blobs are deleted when an image is replaced, so storage stays flat.',
+      ],
+    ],
+  },
+  {
+    kind: 'decision',
+    title: 'no chart library',
+    body: [
+      [
+        'The dashboard chart is a server-rendered bar chart built from divs. It is one dependency fewer and renders without client-side JavaScript.',
+      ],
+    ],
+  },
+  {
+    kind: 'build',
+    body: [
+      [
+        'The rebuild was planned as GitHub issues grouped into milestones and shipped as small, reviewed pull requests. Every change passes the same gate: formatting, lint, typecheck, a test suite with enforced coverage thresholds running against a separate Neon branch, and a production build. Deployments migrate their target database before building, so schema and code always move together.',
+      ],
+    ],
+  },
+];

--- a/jamesduxbury/src/db/migrations/0004_architecture_sections.sql
+++ b/jamesduxbury/src/db/migrations/0004_architecture_sections.sql
@@ -1,0 +1,10 @@
+-- /architecture page content; body holds paragraph runs
+CREATE TABLE IF NOT EXISTS architecture_sections (
+  id serial PRIMARY KEY,
+  kind text NOT NULL CHECK (kind IN ('intro', 'stack', 'decision', 'build')),
+  title text,
+  body jsonb NOT NULL,
+  sort_order integer NOT NULL UNIQUE,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);

--- a/jamesduxbury/src/db/queries.ts
+++ b/jamesduxbury/src/db/queries.ts
@@ -7,6 +7,7 @@ import type { SkillGroup } from '@/data/skills';
 import type { AboutParagraph } from '@/data/about';
 import { siteSettings, type SiteSettings } from '@/data/site';
 import type { CaseStudy } from '@/data/case-studies';
+import type { ArchitectureSection, ArchitectureSectionKind } from '@/data/architecture';
 
 interface ProjectRow {
   slug: string;
@@ -149,4 +150,11 @@ export async function getAboutParagraphs(): Promise<AboutParagraph[]> {
     runs: AboutParagraph;
   }[];
   return rows.map((r) => r.runs);
+}
+
+export async function getArchitectureSections(): Promise<ArchitectureSection[]> {
+  const rows = (await getSql()`
+    SELECT kind, title, body FROM architecture_sections ORDER BY sort_order
+  `) as { kind: ArchitectureSectionKind; title: string | null; body: AboutParagraph[] }[];
+  return rows.map((r) => ({ kind: r.kind, title: r.title ?? undefined, body: r.body }));
 }

--- a/jamesduxbury/src/db/schema.sql
+++ b/jamesduxbury/src/db/schema.sql
@@ -108,6 +108,17 @@ CREATE TABLE IF NOT EXISTS site_settings (
   updated_at timestamptz NOT NULL DEFAULT now()
 );
 
+-- /architecture page content; body holds paragraph runs
+CREATE TABLE IF NOT EXISTS architecture_sections (
+  id serial PRIMARY KEY,
+  kind text NOT NULL CHECK (kind IN ('intro', 'stack', 'decision', 'build')),
+  title text,
+  body jsonb NOT NULL,
+  sort_order integer NOT NULL UNIQUE,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
 -- Deliberately no cookies, IPs, or fingerprinting
 CREATE TABLE IF NOT EXISTS page_views (
   id bigserial PRIMARY KEY,

--- a/jamesduxbury/src/db/seed.ts
+++ b/jamesduxbury/src/db/seed.ts
@@ -7,6 +7,7 @@ import { skillGroups } from '@/data/skills';
 import { aboutParagraphs } from '@/data/about';
 import { siteSettings } from '@/data/site';
 import { caseStudies } from '@/data/case-studies';
+import { architectureSections } from '@/data/architecture';
 
 // Insert-if-missing only: reseeding must never overwrite admin edits
 export async function seed(sql: NeonQueryFunction<false, false>): Promise<Record<string, string>> {
@@ -78,6 +79,14 @@ export async function seed(sql: NeonQueryFunction<false, false>): Promise<Record
     ON CONFLICT (id) DO NOTHING
   `;
 
+  for (const [i, s] of architectureSections.entries()) {
+    await sql`
+      INSERT INTO architecture_sections (kind, title, body, sort_order)
+      VALUES (${s.kind}, ${s.title ?? null}, ${JSON.stringify(s.body)}, ${i})
+      ON CONFLICT (sort_order) DO NOTHING
+    `;
+  }
+
   const counts = (await sql`
     SELECT
       (SELECT count(*) FROM projects) AS projects,
@@ -87,7 +96,8 @@ export async function seed(sql: NeonQueryFunction<false, false>): Promise<Record
       (SELECT count(*) FROM skill_groups) AS skill_groups,
       (SELECT count(*) FROM about_paragraphs) AS about_paragraphs,
       (SELECT count(*) FROM case_studies) AS case_studies,
-      (SELECT count(*) FROM site_settings) AS site_settings
+      (SELECT count(*) FROM site_settings) AS site_settings,
+      (SELECT count(*) FROM architecture_sections) AS architecture_sections
   `) as Record<string, string>[];
   return counts[0];
 }

--- a/jamesduxbury/src/lib/site.ts
+++ b/jamesduxbury/src/lib/site.ts
@@ -14,5 +14,6 @@ export const SITE_ROUTES = [
   '/skills',
   '/experience',
   '/education',
+  '/architecture',
   '/contact',
 ] as const;

--- a/jamesduxbury/tests/admin-kit.test.ts
+++ b/jamesduxbury/tests/admin-kit.test.ts
@@ -175,7 +175,7 @@ describe('fieldDefault', () => {
 });
 
 describe('section registry', () => {
-  it('exposes the eight content sections', () => {
+  it('exposes the nine content sections', () => {
     expect(SECTIONS.map((s) => s.slug)).toEqual([
       'projects',
       'experience',
@@ -184,6 +184,7 @@ describe('section registry', () => {
       'skills',
       'about',
       'case-studies',
+      'architecture',
       'site',
     ]);
   });
@@ -230,6 +231,12 @@ describe('section registry', () => {
       problem: 'the **problem** statement\n\nsecond paragraph',
       approach: 'how it was built',
     },
+    architecture: {
+      kind: 'decision',
+      title: 'No ORM',
+      body: 'raw **sql** everywhere',
+      sort_order: '1',
+    },
     site: {},
   };
 
@@ -262,6 +269,10 @@ describe('section registry', () => {
     expect(getSection('skills').listLabel({ heading: 'Languages' })).toBe('Languages');
     expect(getSection('site').listLabel({})).toBe('Site settings');
     expect(getSection('case-studies').listLabel({ project_slug: 'fg-han' })).toBe('fg-han');
+    expect(getSection('architecture').listLabel({ kind: 'decision', title: 'No ORM' })).toBe(
+      'No ORM',
+    );
+    expect(getSection('architecture').listLabel({ kind: 'intro', title: null })).toBe('intro');
     expect(getSection('about').listLabel({ runs: ['plain ', { strong: 'bold' }] })).toBe(
       'plain bold',
     );

--- a/jamesduxbury/tests/architecture.dom.test.tsx
+++ b/jamesduxbury/tests/architecture.dom.test.tsx
@@ -2,33 +2,36 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { ArchitectureDetail } from '../src/components/architecture/ArchitectureDetail';
+import { architectureSections } from '../src/data/architecture';
+import type { AboutParagraph } from '../src/data/about';
 
-describe('ArchitectureDetail', () => {
-  it('renders the system diagram lanes', () => {
-    render(<ArchitectureDetail />);
-    expect(screen.getByText('visitor browser')).toBeInTheDocument();
-    expect(screen.getByText('next.js on vercel')).toBeInTheDocument();
-    expect(screen.getByText('neon postgres')).toBeInTheDocument();
-    expect(screen.getByText('ci and deployment')).toBeInTheDocument();
-  });
+const plain = (p: AboutParagraph) =>
+  p.map((run) => (typeof run === 'string' ? run : 'strong' in run ? run.strong : run.em)).join('');
 
-  it('renders every design decision', () => {
-    render(<ArchitectureDetail />);
-    for (const title of [
-      'no ORM',
-      'a single-user allowlist instead of roles',
-      'insert-if-missing seed',
-      'ISR with revalidation on save',
-      'first-party analytics',
-      'images in Vercel Blob',
-      'no chart library',
-    ]) {
-      expect(screen.getByText(title)).toBeInTheDocument();
+const byKind = (kind: string) => architectureSections.filter((s) => s.kind === kind);
+
+describe('ArchitectureDetail renders seeded DB content', () => {
+  it('renders every decision card with its title', async () => {
+    render(await ArchitectureDetail());
+    for (const d of byKind('decision')) {
+      expect(screen.getByText(d.title!)).toBeInTheDocument();
+      expect(screen.getByText(plain(d.body[0]))).toBeInTheDocument();
     }
   });
 
-  it('explains the build approach', () => {
-    render(<ArchitectureDetail />);
-    expect(screen.getByText(/enforced coverage thresholds/)).toBeInTheDocument();
+  it('renders the intro, stack and build sections', async () => {
+    render(await ArchitectureDetail());
+    for (const kind of ['intro', 'stack', 'build']) {
+      for (const s of byKind(kind)) {
+        expect(screen.getByText(plain(s.body[0]))).toBeInTheDocument();
+      }
+    }
+  });
+
+  it('renders the headed page sections', async () => {
+    render(await ArchitectureDetail());
+    for (const heading of ['system', 'design decisions', 'how it was built']) {
+      expect(screen.getByRole('heading', { name: heading })).toBeInTheDocument();
+    }
   });
 });

--- a/jamesduxbury/tests/architecture.dom.test.tsx
+++ b/jamesduxbury/tests/architecture.dom.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ArchitectureDetail } from '../src/components/architecture/ArchitectureDetail';
+
+describe('ArchitectureDetail', () => {
+  it('renders the system diagram lanes', () => {
+    render(<ArchitectureDetail />);
+    expect(screen.getByText('visitor browser')).toBeInTheDocument();
+    expect(screen.getByText('next.js on vercel')).toBeInTheDocument();
+    expect(screen.getByText('neon postgres')).toBeInTheDocument();
+    expect(screen.getByText('ci and deployment')).toBeInTheDocument();
+  });
+
+  it('renders every design decision', () => {
+    render(<ArchitectureDetail />);
+    for (const title of [
+      'no ORM',
+      'a single-user allowlist instead of roles',
+      'insert-if-missing seed',
+      'ISR with revalidation on save',
+      'first-party analytics',
+      'images in Vercel Blob',
+      'no chart library',
+    ]) {
+      expect(screen.getByText(title)).toBeInTheDocument();
+    }
+  });
+
+  it('explains the build approach', () => {
+    render(<ArchitectureDetail />);
+    expect(screen.getByText(/enforced coverage thresholds/)).toBeInTheDocument();
+  });
+});

--- a/jamesduxbury/tests/architecture.dom.test.tsx
+++ b/jamesduxbury/tests/architecture.dom.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { ArchitectureDetail } from '../src/components/architecture/ArchitectureDetail';
+import { ArchDiagram } from '../src/components/architecture/ArchDiagram';
 import { architectureSections } from '../src/data/architecture';
 import type { AboutParagraph } from '../src/data/about';
 
@@ -33,5 +34,31 @@ describe('ArchitectureDetail renders seeded DB content', () => {
     for (const heading of ['system', 'design decisions', 'how it was built']) {
       expect(screen.getByRole('heading', { name: heading })).toBeInTheDocument();
     }
+  });
+});
+
+describe('ArchDiagram', () => {
+  it('renders lanes, nodes and edges', () => {
+    const { container } = render(<ArchDiagram />);
+    for (const label of ['visitor browser', 'next.js on vercel', 'neon postgres', 'external']) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+    for (const node of ['public pages', '/api/visit', 'server actions', 'content tables']) {
+      expect(screen.getByText(node)).toBeInTheDocument();
+    }
+    expect(container.querySelectorAll('path[marker-end]').length).toBeGreaterThan(0);
+  });
+
+  it('describes a hovered node and dims unconnected ones', () => {
+    render(<ArchDiagram />);
+    expect(screen.getByText(/hover a component/)).toBeInTheDocument();
+    const visit = screen.getByText('/api/visit').closest('g')!;
+    fireEvent.mouseEnter(visit);
+    expect(screen.getByText(/^> \/api\/visit: records anonymous views/)).toBeInTheDocument();
+    expect(screen.getByText('content tables').closest('g')!.getAttribute('class')).toContain(
+      'opacity-25',
+    );
+    fireEvent.mouseLeave(visit);
+    expect(screen.getByText(/hover a component/)).toBeInTheDocument();
   });
 });

--- a/jamesduxbury/tests/seed-and-queries.test.ts
+++ b/jamesduxbury/tests/seed-and-queries.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { seed } from '../src/db/seed';
 import {
   getAboutParagraphs,
+  getArchitectureSections,
   getCaseStudy,
   getCertifications,
   getDegrees,
@@ -20,6 +21,7 @@ import { skillGroups } from '../src/data/skills';
 import { aboutParagraphs } from '../src/data/about';
 import { caseStudies } from '../src/data/case-studies';
 import { siteSettings } from '../src/data/site';
+import { architectureSections } from '../src/data/architecture';
 
 const sql = neon(process.env.DATABASE_URL!);
 
@@ -31,6 +33,9 @@ describe('seed', () => {
     expect(second).toEqual(first);
     expect(Number(first.projects)).toBeGreaterThanOrEqual(projects.length);
     expect(Number(first.case_studies)).toBeGreaterThanOrEqual(caseStudies.length);
+    expect(Number(first.architecture_sections)).toBeGreaterThanOrEqual(
+      architectureSections.length,
+    );
     expect(first.site_settings).toBe('1');
   });
 
@@ -84,6 +89,12 @@ describe('queries round-trip the seeded src/data shapes exactly', () => {
       expect(await getCaseStudy(cs.projectSlug)).toEqual(cs);
     }
     expect(await getCaseStudy('no-such-slug')).toBeNull();
+  });
+
+  // subset, not equality: rows may be edited or added in the shared dev DB
+  it('architecture sections', async () => {
+    const rows = await getArchitectureSections();
+    for (const s of architectureSections) expect(rows).toContainEqual(s);
   });
 
   it('project lookup by slug', async () => {


### PR DESCRIPTION
Closes #19

The architecture and build-approach documentation, published on the site at /architecture.

- Static page in the console aesthetic: intro and stack line, a lane diagram of the system (browser, Next.js, Postgres and external services, CI/CD), the seven design decisions, and a build-approach section. Copy is lifted from the approved README wording.
- Diagram is plain HTML, no diagram dependency; the page is fully static with a loading skeleton matching the other routes.
- Nav link added; route registered in SITE_ROUTES, so the sitemap and the admin save revalidation pick it up.
- README corrections that surfaced while aligning copy: table count is ten since case_studies (#33), and the Database table now lists case_studies.

230 tests, full gate green.