### PR TITLE
ci: codecov integration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,21 @@ jobs:
           GITHUB_SECRET: ci-dummy
           AUTH_SECRET: ci-dummy-secret-for-build-only
 
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: jamesduxbury/coverage/lcov.info
+          fail_ci_if_error: false
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: jamesduxbury/coverage/junit.xml
+
       - name: Build
         run: npm run build
         env:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # jamesduxbury-dot-com
 
+[![codecov](https://codecov.io/gh/jsduxie/jamesduxbury-dot-com/graph/badge.svg)](https://codecov.io/gh/jsduxie/jamesduxbury-dot-com)
+
 Source code for my personal portfolio website: [jamesduxbury-dot-com.vercel.app](https://jamesduxbury-dot-com.vercel.app)
 
 The site started as a static portfolio and is now a full-stack application. All content is stored in Postgres and editable through an authenticated admin console, so I can update the site without a code push. Visits are tracked first-party and shown on an analytics dashboard.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,44 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: '85...100'
+  status:
+    project:
+      default:
+        target: 90%
+        threshold: 0%
+    patch:
+      default:
+        target: 85%
+        threshold: 0%
+
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: 85%
+        threshold: 0%
+  individual_components:
+    - component_id: db
+      paths: ['jamesduxbury/src/db/**']
+    - component_id: admin
+      paths: ['jamesduxbury/src/admin/**', 'jamesduxbury/src/app/admin/**']
+    - component_id: api
+      paths: ['jamesduxbury/src/app/api/**']
+    - component_id: components
+      paths: ['jamesduxbury/src/components/**']
+    - component_id: lib
+      paths:
+        ['jamesduxbury/src/lib/**', 'jamesduxbury/src/auth.ts', 'jamesduxbury/src/middleware.ts']
+
+comment:
+  layout: 'header, diff, components, files, footer'
+  behavior: default
+  require_changes: false
+
+ignore:
+  - 'jamesduxbury/tests/**'
+  - 'jamesduxbury/scripts/**'

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,10 @@
 codecov:
   require_ci_to_pass: true
 
+# vitest reports paths relative to jamesduxbury/; map them onto the repo tree
+fixes:
+  - '::jamesduxbury/'
+
 coverage:
   precision: 2
   round: down

--- a/jamesduxbury/vitest.config.ts
+++ b/jamesduxbury/vitest.config.ts
@@ -25,8 +25,12 @@ export default defineConfig({
     fileParallelism: false,
     setupFiles: ['./tests/setup.ts'],
     include: ['tests/**/*.test.{ts,tsx}'],
+    // junit feeds Codecov test analytics; written into the gitignored coverage dir
+    reporters: ['default', 'junit'],
+    outputFile: { junit: 'coverage/junit.xml' },
     coverage: {
       provider: 'v8',
+      reporter: ['text', 'lcov'],
       include: ['src/**/*.{ts,tsx}'],
       // Page shells and the OG card are covered by the build-time HTML diff, not unit tests
       exclude: [


### PR DESCRIPTION
Closes #42

Mirrors the researcher-agent setup:

- vitest gains lcov coverage and junit reporters (outputs under the gitignored coverage dir)
- check job uploads coverage (codecov-action@v4) and test results (test-results-action@v1), fail_ci_if_error false
- codecov.yml: project 90% / patch 85% aligned with the enforced vitest thresholds, component statuses (db, admin, api, components, lib), PR comment with components, a fixes rule mapping the jamesduxbury/ subdirectory onto the repo tree (validated against the codecov.io/validate endpoint)
- README coverage badge

Verified locally: 241 tests green, lcov.info and junit.xml emitted where the upload steps expect them.