### PR TITLE
feat(auth): allowlist from the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ All site content (projects, experience, education, certifications, skills, about
 
 Sign-in is GitHub OAuth through next-auth v5 with JWT sessions and no database adapter. Only my GitHub account can sign in: the allowlist is checked by identity at four layers: the signIn callback, the middleware on `/admin/*`, the admin layout, and every server action. Visiting `/admin` while signed out goes straight into the OAuth flow.
 
+The allowed login is stored in `site_settings.admin_login` and editable from the console, so a GitHub username change is a settings edit rather than a deploy. The check reads the value once per request and fails closed when it is missing or empty. A typo in the field locks the console; recovery is one statement in the Neon SQL editor: `UPDATE site_settings SET admin_login = '<login>' WHERE id = 1`.
+
 ### Admin console
 
 Each content section is defined once in a registry (`src/admin/sections.ts`) as field config plus a Zod schema. The list, create, edit and delete pages, the form rendering, and the SQL are all generic, so adding a section is configuration rather than new code. The console also has a messages inbox and the analytics dashboard.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ All site content (projects, experience, education, certifications, skills, about
 
 Sign-in is GitHub OAuth through next-auth v5 with JWT sessions and no database adapter. Only my GitHub account can sign in: the allowlist is checked by identity at four layers: the signIn callback, the middleware on `/admin/*`, the admin layout, and every server action. Visiting `/admin` while signed out goes straight into the OAuth flow.
 
-The allowed login is stored in `site_settings.admin_login` and editable from the console, so a GitHub username change is a settings edit rather than a deploy. The check reads the value once per request and fails closed when it is missing or empty. A typo in the field locks the console; recovery is one statement in the Neon SQL editor: `UPDATE site_settings SET admin_login = '<login>' WHERE id = 1`.
+The allowed login is stored in `site_settings.admin_login` and editable from the console, so a GitHub username change is a settings edit rather than a deploy. The check reads the value once per request and fails closed when it is missing or empty. A typo in the field locks the console until the value is corrected directly in the database.
 
 ### Admin console
 

--- a/jamesduxbury/src/admin/actions.ts
+++ b/jamesduxbury/src/admin/actions.ts
@@ -16,7 +16,7 @@ export interface FormState {
 }
 
 async function requireAdmin(): Promise<void> {
-  if (!isAdminSession(await auth())) throw new Error('Unauthorised');
+  if (!(await isAdminSession(await auth()))) throw new Error('Unauthorised');
 }
 
 function uploadFields(fields: FieldDef[]): FieldDef[] {

--- a/jamesduxbury/src/admin/sections.ts
+++ b/jamesduxbury/src/admin/sections.ts
@@ -282,6 +282,12 @@ export const SECTIONS: SectionConfig[] = [
       { column: 'entry_status', label: 'Entry status', type: 'text' },
       { column: 'entry_years', label: 'Entry years', type: 'text' },
       {
+        column: 'admin_login',
+        label: 'Admin login',
+        type: 'text',
+        help: 'github account allowed into this console; a typo locks you out until fixed in the neon sql editor',
+      },
+      {
         column: 'cv',
         label: 'CV',
         type: 'document',
@@ -304,6 +310,9 @@ export const SECTIONS: SectionConfig[] = [
       entry_education: z.string().min(1),
       entry_status: z.string().min(1),
       entry_years: z.string().min(1),
+      admin_login: z
+        .string()
+        .regex(/^[a-zA-Z0-9-]{1,39}$/, 'github usernames are alphanumeric with hyphens'),
       cv: z.string().min(1).nullable(),
     }),
     listLabel: () => 'Site settings',

--- a/jamesduxbury/src/admin/sections.ts
+++ b/jamesduxbury/src/admin/sections.ts
@@ -312,7 +312,10 @@ export const SECTIONS: SectionConfig[] = [
       entry_years: z.string().min(1),
       admin_login: z
         .string()
-        .regex(/^[a-zA-Z0-9-]{1,39}$/, 'github usernames are alphanumeric with hyphens'),
+        .regex(
+          /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/,
+          'github usernames are alphanumeric; single hyphens only, none leading or trailing',
+        ),
       cv: z.string().min(1).nullable(),
     }),
     listLabel: () => 'Site settings',

--- a/jamesduxbury/src/app/admin/layout.tsx
+++ b/jamesduxbury/src/app/admin/layout.tsx
@@ -17,7 +17,7 @@ const navLink =
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
   const session = await auth();
-  if (!isAdminSession(session)) redirect('/signin');
+  if (!(await isAdminSession(session))) redirect('/signin');
 
   return (
     <div className="mx-auto max-w-5xl px-4 pb-10 pt-28 sm:px-6 sm:pt-32">

--- a/jamesduxbury/src/app/api/visit/route.ts
+++ b/jamesduxbury/src/app/api/visit/route.ts
@@ -17,7 +17,7 @@ export async function POST(req: Request) {
     return new Response(null, { status: 204 });
   }
   // skips the signed-in admin's visits
-  if (isAdminSession(await auth())) {
+  if (await isAdminSession(await auth())) {
     return new Response(null, { status: 204 });
   }
 

--- a/jamesduxbury/src/app/signin/page.tsx
+++ b/jamesduxbury/src/app/signin/page.tsx
@@ -15,7 +15,7 @@ export default async function SignInPage({
   searchParams: Promise<{ callbackUrl?: string; error?: string }>;
 }) {
   const session = await auth();
-  if (isAdminSession(session)) redirect('/admin');
+  if (await isAdminSession(session)) redirect('/admin');
   const { callbackUrl, error } = await searchParams;
 
   return (

--- a/jamesduxbury/src/auth.ts
+++ b/jamesduxbury/src/auth.ts
@@ -1,6 +1,7 @@
 import NextAuth, { type Profile, type Session } from 'next-auth';
 import type { JWT } from 'next-auth/jwt';
 import GitHub from 'next-auth/providers/github';
+import { getAdminLogin } from '@/db/queries';
 
 declare module 'next-auth' {
   interface User {
@@ -8,14 +9,13 @@ declare module 'next-auth' {
   }
 }
 
-// github account allowed to sign in
-export const ALLOWED_LOGIN = 'jsduxie';
-
-export function isAllowedLogin(login: unknown): boolean {
-  return login === ALLOWED_LOGIN;
+// the login lives in site_settings, so a rename invalidates old sessions at once
+export async function isAllowedLogin(login: unknown): Promise<boolean> {
+  if (typeof login !== 'string' || login === '') return false;
+  return login === (await getAdminLogin());
 }
 
-export function isAdminSession(session: Session | null): boolean {
+export async function isAdminSession(session: Session | null): Promise<boolean> {
   return isAllowedLogin(session?.user?.login);
 }
 

--- a/jamesduxbury/src/db/migrations/0006_admin_login.sql
+++ b/jamesduxbury/src/db/migrations/0006_admin_login.sql
@@ -1,0 +1,3 @@
+-- console allowlist moves out of code; the default is the previously hardcoded login
+ALTER TABLE site_settings
+  ADD COLUMN IF NOT EXISTS admin_login text NOT NULL DEFAULT 'jsduxie';

--- a/jamesduxbury/src/db/queries.ts
+++ b/jamesduxbury/src/db/queries.ts
@@ -158,6 +158,15 @@ interface SiteSettingsRow {
   cv: string | null;
 }
 
+// auth-owned read with no fallback: a missing or empty value must fail closed
+export const getAdminLogin = cache(async (): Promise<string | null> => {
+  const rows = (await getSql()`SELECT admin_login FROM site_settings WHERE id = 1`) as {
+    admin_login: string;
+  }[];
+  const login = rows[0]?.admin_login.trim();
+  return login ? login : null;
+});
+
 // cache() shares the single settings row across every reader in one request
 export const getSiteSettings = cache(async (): Promise<SiteSettings> => {
   const rows = (await getSql()`SELECT * FROM site_settings WHERE id = 1`) as SiteSettingsRow[];

--- a/jamesduxbury/src/db/schema.sql
+++ b/jamesduxbury/src/db/schema.sql
@@ -117,6 +117,7 @@ CREATE TABLE IF NOT EXISTS site_settings (
   entry_education text NOT NULL DEFAULT 'Durham University · Integrated MEng Computer Science',
   entry_status text NOT NULL DEFAULT 'FINAL YEAR',
   entry_years text NOT NULL DEFAULT '2022 — 2026',
+  admin_login text NOT NULL DEFAULT 'jsduxie',
   -- blob URL; public CV links fall back to /data/CV.pdf while NULL
   cv text,
   sort_order integer NOT NULL DEFAULT 0,

--- a/jamesduxbury/src/middleware.ts
+++ b/jamesduxbury/src/middleware.ts
@@ -4,8 +4,8 @@ import type { NextRequest } from 'next/server';
 
 type AuthedRequest = NextRequest & { auth: Session | null };
 
-export function requireAdmin(req: AuthedRequest): Response | undefined {
-  if (isAdminSession(req.auth)) return undefined;
+export async function requireAdmin(req: AuthedRequest): Promise<Response | undefined> {
+  if (await isAdminSession(req.auth)) return undefined;
   const url = new URL('/signin', req.nextUrl.origin);
   url.searchParams.set('callbackUrl', req.nextUrl.href);
   return Response.redirect(url);

--- a/jamesduxbury/tests/admin-actions.test.ts
+++ b/jamesduxbury/tests/admin-actions.test.ts
@@ -256,6 +256,7 @@ function siteForm(): FormData {
   fd.append('entry_education', siteSettings.entryEducation);
   fd.append('entry_status', siteSettings.entryStatus);
   fd.append('entry_years', siteSettings.entryYears);
+  fd.append('admin_login', 'jsduxie');
   return fd;
 }
 

--- a/jamesduxbury/tests/admin-kit.test.ts
+++ b/jamesduxbury/tests/admin-kit.test.ts
@@ -252,6 +252,7 @@ describe('section registry', () => {
       entry_education: 'Durham',
       entry_status: 'FINAL YEAR',
       entry_years: '2022 - 2026',
+      admin_login: 'jsduxie',
     },
   };
 

--- a/jamesduxbury/tests/auth.test.ts
+++ b/jamesduxbury/tests/auth.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { neon } from '@neondatabase/serverless';
+import { afterEach, describe, expect, it } from 'vitest';
 import type { Session } from 'next-auth';
 import type { NextRequest } from 'next/server';
 import type { JWT } from 'next-auth/jwt';
 import {
-  ALLOWED_LOGIN,
   auth,
   authCallbacks,
   handlers,
@@ -17,6 +17,8 @@ import { GET, POST } from '../src/app/api/auth/[...nextauth]/route';
 
 type AuthedRequest = Parameters<typeof requireAdmin>[0];
 
+const sql = neon(process.env.DATABASE_URL!);
+
 function request(href: string, session: Session | null): AuthedRequest {
   const url = new URL(href);
   return { auth: session, nextUrl: url } as NextRequest & { auth: Session | null };
@@ -26,26 +28,42 @@ function sessionFor(login?: string): Session {
   return { user: { name: 'James', login }, expires: '2099-01-01T00:00:00.000Z' };
 }
 
+// the allowlist lives in the dev DB now; every mutation restores it
+afterEach(async () => {
+  await sql`UPDATE site_settings SET admin_login = 'jsduxie' WHERE id = 1`;
+});
+
 describe('allowlist', () => {
-  it('allows exactly the jsduxie login', () => {
-    expect(ALLOWED_LOGIN).toBe('jsduxie');
-    expect(isAllowedLogin('jsduxie')).toBe(true);
+  it('allows exactly the stored login', async () => {
+    expect(await isAllowedLogin('jsduxie')).toBe(true);
   });
 
   it.each(['JSDuxie', 'jsduxie2', 'octocat', '', undefined, null, 42])(
     'rejects %j',
-    (login) => {
-      expect(isAllowedLogin(login)).toBe(false);
+    async (login) => {
+      expect(await isAllowedLogin(login)).toBe(false);
     },
   );
+
+  it('follows a rename: the old login is rejected and the new one accepted', async () => {
+    await sql`UPDATE site_settings SET admin_login = 'renamed-user' WHERE id = 1`;
+    expect(await isAllowedLogin('jsduxie')).toBe(false);
+    expect(await isAllowedLogin('renamed-user')).toBe(true);
+  });
+
+  it('fails closed on an empty stored value', async () => {
+    await sql`UPDATE site_settings SET admin_login = '' WHERE id = 1`;
+    expect(await isAllowedLogin('jsduxie')).toBe(false);
+    expect(await isAllowedLogin('')).toBe(false);
+  });
 });
 
 describe('isAdminSession', () => {
-  it('accepts only a session carrying the allowed login', () => {
-    expect(isAdminSession(sessionFor('jsduxie'))).toBe(true);
-    expect(isAdminSession(sessionFor('octocat'))).toBe(false);
-    expect(isAdminSession(sessionFor(undefined))).toBe(false);
-    expect(isAdminSession(null)).toBe(false);
+  it('accepts only a session carrying the allowed login', async () => {
+    expect(await isAdminSession(sessionFor('jsduxie'))).toBe(true);
+    expect(await isAdminSession(sessionFor('octocat'))).toBe(false);
+    expect(await isAdminSession(sessionFor(undefined))).toBe(false);
+    expect(await isAdminSession(null)).toBe(false);
   });
 });
 
@@ -58,10 +76,10 @@ describe('NextAuth wiring', () => {
     expect(typeof signOut).toBe('function');
   });
 
-  it('signIn admits only the allowed GitHub profile', () => {
-    expect(authCallbacks.signIn({ profile: { login: 'jsduxie' } })).toBe(true);
-    expect(authCallbacks.signIn({ profile: { login: 'octocat' } })).toBe(false);
-    expect(authCallbacks.signIn({})).toBe(false);
+  it('signIn admits only the allowed GitHub profile', async () => {
+    expect(await authCallbacks.signIn({ profile: { login: 'jsduxie' } })).toBe(true);
+    expect(await authCallbacks.signIn({ profile: { login: 'octocat' } })).toBe(false);
+    expect(await authCallbacks.signIn({})).toBe(false);
   });
 
   it('jwt stores the login at sign-in and keeps it afterwards', () => {
@@ -85,9 +103,9 @@ describe('admin middleware', () => {
     expect(config.matcher).toEqual(['/admin/:path*']);
   });
 
-  it('lets the allowed account through', () => {
+  it('lets the allowed account through', async () => {
     expect(
-      requireAdmin(request('http://localhost:3000/admin/projects', sessionFor('jsduxie'))),
+      await requireAdmin(request('http://localhost:3000/admin/projects', sessionFor('jsduxie'))),
     ).toBeUndefined();
   });
 
@@ -95,8 +113,8 @@ describe('admin middleware', () => {
     ['anonymous', null],
     ['wrong account', sessionFor('octocat')],
     ['session without a login claim', sessionFor(undefined)],
-  ])('redirects a %s request to signin with a callback', (_name, session) => {
-    const res = requireAdmin(request('http://localhost:3000/admin/projects', session));
+  ])('redirects a %s request to signin with a callback', async (_name, session) => {
+    const res = await requireAdmin(request('http://localhost:3000/admin/projects', session));
     expect(res).toBeInstanceOf(Response);
     const location = new URL(res!.headers.get('location')!);
     expect(location.pathname).toBe('/signin');


### PR DESCRIPTION
Part two of #40, stacked on #44 (closes #40 once both merge).

- site_settings.admin_login (default jsduxie) replaces the hardcoded constant; editable at /admin/site behind a GitHub-username regex.
- isAllowedLogin/isAdminSession compare the session identity to the stored value, still enforced at every layer: signIn callback, middleware, admin layout, every server action, and the /api/visit exclusion. The read is request-cached, so it is one query per request rather than one per layer.
- Fails closed: a missing or empty value rejects everyone, and a DB error rejects with a 500 rather than allowing. Renaming the login invalidates sessions under the old name on their next request. Lockout recovery documented in the README (one UPDATE in the Neon SQL editor).
- Auth tests are now integration tests against the dev database, covering the rename and fail-closed paths.

Verified: 246 tests green, build clean including the edge middleware bundle.

Merge order: #44 first, then this (GitHub retargets it to main automatically).