### PR TITLE
fix(admin): clear images and reconcile dead blobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ Each content section is defined once in a registry (`src/admin/sections.ts`) as 
 
 ### Images
 
-Site images (the profile picture, certification badges, project images) live in Vercel Blob and are served from its CDN. The admin form kit has an upload field type: saving uploads the file, writes its URL to the row, and deletes the blob it replaced; deleting a row deletes its blobs, so the store never accumulates unused files. Each environment uploads its own copies, which keeps a replacement in one environment from breaking the other.
+Site images (the profile picture, certification badges, project images) live in Vercel Blob and are served from its CDN. The admin form kit has upload field types for images and the CV: saving uploads the file, writes its URL to the row, and deletes the blob it replaced; deleting a row deletes its blobs, and a remove checkbox clears an optional image. Each environment uploads under its own prefix in the shared store, so a replacement or purge in one never touches the other.
+
+If a blob is deleted out of band the public pages hide the missing image rather than render a broken frame. A maintenance page in the console reconciles the store: it clears references whose blob has vanished and deletes blobs no row points at, scoped to the current environment's prefix.
 
 ### Analytics
 

--- a/jamesduxbury/src/admin/actions.ts
+++ b/jamesduxbury/src/admin/actions.ts
@@ -60,10 +60,16 @@ export async function saveItem(
       files.set(f.column, raw);
     }
   }
-  // an empty file input keeps the stored image
+  // a new file wins over a remove request; otherwise remove clears, empty keeps
+  const removed = new Set(
+    images
+      .filter((f) => !files.has(f.column) && formData.get(`${f.column}.remove`) === 'on')
+      .map((f) => f.column),
+  );
   const prior = id !== null && images.length > 0 ? await getRow(section.table, id) : null;
   for (const f of images) {
-    if (!files.has(f.column)) values[f.column] = (prior?.[f.column] as FieldValue) ?? null;
+    if (files.has(f.column)) continue;
+    values[f.column] = removed.has(f.column) ? null : ((prior?.[f.column] as FieldValue) ?? null);
   }
 
   const parsed = section.schema.safeParse(values);
@@ -94,7 +100,10 @@ export async function saveItem(
     return { message: err instanceof Error ? err.message : 'Save failed', fieldErrors: {} };
   }
 
-  if (prior !== null) for (const column of files.keys()) await deleteImage(prior[column]);
+  if (prior !== null) {
+    for (const column of files.keys()) await deleteImage(prior[column]);
+    for (const column of removed) await deleteImage(prior[column]);
+  }
 
   revalidatePublicPages();
   revalidatePath(`/admin/${slug}`);

--- a/jamesduxbury/src/admin/actions.ts
+++ b/jamesduxbury/src/admin/actions.ts
@@ -7,6 +7,7 @@ import { markRead } from '@/db/messages';
 import { SITE_ROUTES } from '@/lib/site';
 import { parseFields, type FieldDef, type FieldValue } from './fields';
 import { deleteImage, documentFileError, imageFileError, uploadImage } from './images';
+import { runBlobMaintenance, type MaintenanceReport } from './maintenance';
 import { getSection } from './sections';
 import { deleteRow, getRow, insertRow, makeRoomAt, updateRow } from './sql';
 
@@ -22,6 +23,9 @@ async function requireAdmin(): Promise<void> {
 function uploadFields(fields: FieldDef[]): FieldDef[] {
   return fields.filter((f) => f.type === 'image' || f.type === 'document');
 }
+
+// stand-in so a non-nullable upload column validates before its file is uploaded
+const PENDING_UPLOAD = '(pending upload)';
 
 function revalidatePublicPages(): void {
   for (const route of SITE_ROUTES) revalidatePath(route);
@@ -68,8 +72,10 @@ export async function saveItem(
   );
   const prior = id !== null && images.length > 0 ? await getRow(section.table, id) : null;
   for (const f of images) {
-    if (files.has(f.column)) continue;
-    values[f.column] = removed.has(f.column) ? null : ((prior?.[f.column] as FieldValue) ?? null);
+    // a pending upload validates as present; the real URL replaces this after upload
+    if (files.has(f.column)) values[f.column] = PENDING_UPLOAD;
+    else
+      values[f.column] = removed.has(f.column) ? null : ((prior?.[f.column] as FieldValue) ?? null);
   }
 
   const parsed = section.schema.safeParse(values);
@@ -125,4 +131,14 @@ export async function markMessageRead(id: number): Promise<void> {
   await requireAdmin();
   await markRead(id);
   revalidatePath('/admin/messages');
+}
+
+export async function runMaintenance(
+  _prev: MaintenanceReport | null,
+  _formData: FormData,
+): Promise<MaintenanceReport> {
+  await requireAdmin();
+  const report = await runBlobMaintenance();
+  if (report.healed.length > 0) revalidatePublicPages();
+  return report;
 }

--- a/jamesduxbury/src/admin/actions.ts
+++ b/jamesduxbury/src/admin/actions.ts
@@ -5,7 +5,7 @@ import { redirect } from 'next/navigation';
 import { auth, isAdminSession } from '@/auth';
 import { markRead } from '@/db/messages';
 import { SITE_ROUTES } from '@/lib/site';
-import { parseFields, type FieldDef, type FieldValue } from './fields';
+import { isUploadField, parseFields, type FieldDef, type FieldValue } from './fields';
 import { deleteImage, documentFileError, imageFileError, uploadImage } from './images';
 import { runBlobMaintenance, type MaintenanceReport } from './maintenance';
 import { getSection } from './sections';
@@ -21,7 +21,7 @@ async function requireAdmin(): Promise<void> {
 }
 
 function uploadFields(fields: FieldDef[]): FieldDef[] {
-  return fields.filter((f) => f.type === 'image' || f.type === 'document');
+  return fields.filter(isUploadField);
 }
 
 // stand-in so a non-nullable upload column validates before its file is uploaded

--- a/jamesduxbury/src/admin/fields.ts
+++ b/jamesduxbury/src/admin/fields.ts
@@ -26,6 +26,10 @@ export interface FieldDef {
   help?: string;
 }
 
+export function isUploadField(field: FieldDef): boolean {
+  return field.type === 'image' || field.type === 'document';
+}
+
 export interface MetricDraft {
   label: string;
   value: string;

--- a/jamesduxbury/src/admin/images.ts
+++ b/jamesduxbury/src/admin/images.ts
@@ -1,8 +1,13 @@
-import { del, put } from '@vercel/blob';
+import { del, list, put } from '@vercel/blob';
 
 const ALLOWED_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp']);
 // matches the serverActions bodySizeLimit in next.config.ts
 const MAX_BYTES = 4 * 1024 * 1024;
+
+// one shared store, two DBs: the prefix scopes a purge to its own environment
+export function blobEnv(): string {
+  return process.env.VERCEL_ENV === 'production' ? 'prod' : 'dev';
+}
 
 export function imageFileError(file: File): string | null {
   if (!ALLOWED_TYPES.has(file.type)) return 'Image must be png, jpeg or webp';
@@ -25,7 +30,10 @@ export function isBlobUrl(url: string): boolean {
 }
 
 export async function uploadImage(file: File): Promise<string> {
-  const { url } = await put(file.name, file, { access: 'public', addRandomSuffix: true });
+  const { url } = await put(`${blobEnv()}/${file.name}`, file, {
+    access: 'public',
+    addRandomSuffix: true,
+  });
   return url;
 }
 
@@ -37,4 +45,26 @@ export async function deleteImage(url: unknown): Promise<void> {
   } catch {
     // a failed delete only leaves an orphan; the row no longer references it
   }
+}
+
+// only a definitive 404 counts as gone; a transient error must never trigger a heal or purge
+export async function blobIsAlive(url: string): Promise<boolean> {
+  try {
+    const res = await fetch(url, { method: 'HEAD', cache: 'no-store' });
+    return res.status !== 404;
+  } catch {
+    return true;
+  }
+}
+
+// blobs under this environment's prefix only, so a purge never touches the other env
+export async function listEnvBlobs(): Promise<string[]> {
+  const urls: string[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await list({ prefix: `${blobEnv()}/`, cursor });
+    for (const blob of page.blobs) urls.push(blob.url);
+    cursor = page.hasMore ? page.cursor : undefined;
+  } while (cursor);
+  return urls;
 }

--- a/jamesduxbury/src/admin/maintenance.ts
+++ b/jamesduxbury/src/admin/maintenance.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod';
+import { getSql } from '@/db';
+import { SECTIONS } from './sections';
+import { blobIsAlive, deleteImage, isBlobUrl, listEnvBlobs } from './images';
+
+interface UploadRef {
+  table: string;
+  column: string;
+  // non-nullable columns (profile_image) are reported rather than nulled
+  nullable: boolean;
+}
+
+function uploadRefs(): UploadRef[] {
+  const refs: UploadRef[] = [];
+  for (const section of SECTIONS) {
+    const shape = (section.schema as unknown as z.ZodObject<z.ZodRawShape>).shape as Record<
+      string,
+      z.ZodType
+    >;
+    for (const field of section.fields) {
+      if (field.type !== 'image' && field.type !== 'document') continue;
+      refs.push({
+        table: section.table,
+        column: field.column,
+        nullable: shape[field.column].safeParse(null).success,
+      });
+    }
+  }
+  return refs;
+}
+
+// every store-owned blob URL currently referenced by a row, mapped to its references
+async function referencedUrls(): Promise<Map<string, UploadRef[]>> {
+  const map = new Map<string, UploadRef[]>();
+  for (const ref of uploadRefs()) {
+    const rows = (await getSql().query(
+      `SELECT DISTINCT ${ref.column} AS url FROM ${ref.table} WHERE ${ref.column} IS NOT NULL`,
+    )) as { url: string }[];
+    for (const { url } of rows) {
+      if (!isBlobUrl(url)) continue;
+      const pointers = map.get(url) ?? [];
+      pointers.push(ref);
+      map.set(url, pointers);
+    }
+  }
+  return map;
+}
+
+export interface MaintenanceReport {
+  healed: { table: string; column: string }[];
+  dangling: { table: string; column: string; url: string }[];
+  purged: number;
+}
+
+// nulls references whose blob has vanished, then deletes blobs no row references
+export async function runBlobMaintenance(): Promise<MaintenanceReport> {
+  const report: MaintenanceReport = { healed: [], dangling: [], purged: 0 };
+
+  for (const [url, pointers] of await referencedUrls()) {
+    if (await blobIsAlive(url)) continue;
+    for (const ref of pointers) {
+      if (ref.nullable) {
+        await getSql().query(
+          `UPDATE ${ref.table} SET ${ref.column} = NULL WHERE ${ref.column} = $1`,
+          [url],
+        );
+        report.healed.push({ table: ref.table, column: ref.column });
+      } else {
+        report.dangling.push({ table: ref.table, column: ref.column, url });
+      }
+    }
+  }
+
+  const referenced = new Set((await referencedUrls()).keys());
+  for (const url of await listEnvBlobs()) {
+    if (referenced.has(url)) continue;
+    await deleteImage(url);
+    report.purged += 1;
+  }
+  return report;
+}

--- a/jamesduxbury/src/admin/maintenance.ts
+++ b/jamesduxbury/src/admin/maintenance.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { getSql } from '@/db';
+import { isUploadField } from './fields';
 import { SECTIONS } from './sections';
 import { blobIsAlive, deleteImage, isBlobUrl, listEnvBlobs } from './images';
 
@@ -18,7 +19,7 @@ function uploadRefs(): UploadRef[] {
       z.ZodType
     >;
     for (const field of section.fields) {
-      if (field.type !== 'image' && field.type !== 'document') continue;
+      if (!isUploadField(field)) continue;
       refs.push({
         table: section.table,
         column: field.column,
@@ -56,7 +57,8 @@ export interface MaintenanceReport {
 export async function runBlobMaintenance(): Promise<MaintenanceReport> {
   const report: MaintenanceReport = { healed: [], dangling: [], purged: 0 };
 
-  for (const [url, pointers] of await referencedUrls()) {
+  const referenced = await referencedUrls();
+  for (const [url, pointers] of referenced) {
     if (await blobIsAlive(url)) continue;
     for (const ref of pointers) {
       if (ref.nullable) {
@@ -71,7 +73,8 @@ export async function runBlobMaintenance(): Promise<MaintenanceReport> {
     }
   }
 
-  const referenced = new Set((await referencedUrls()).keys());
+  // healing only nulls references to dead blobs, which are not in the store, so the
+  // referenced keys above are already the correct keep-set for the purge
   for (const url of await listEnvBlobs()) {
     if (referenced.has(url)) continue;
     await deleteImage(url);

--- a/jamesduxbury/src/admin/sections.ts
+++ b/jamesduxbury/src/admin/sections.ts
@@ -295,7 +295,8 @@ export const SECTIONS: SectionConfig[] = [
       },
     ],
     schema: z.object({
-      profile_image: z.string().min(1).nullable(),
+      // non-nullable: clearing the profile image fails validation rather than the DB
+      profile_image: z.string().min(1),
       owner_name: z.string().min(1),
       tagline: z.string().min(1),
       contact_email: z.email(),

--- a/jamesduxbury/src/app/admin/maintenance/page.tsx
+++ b/jamesduxbury/src/app/admin/maintenance/page.tsx
@@ -1,0 +1,12 @@
+import { AdminPanel } from '@/components/admin/AdminPanel';
+import { MaintenancePanel } from '@/components/admin/MaintenancePanel';
+
+export default function MaintenancePage() {
+  return (
+    <AdminPanel title="blob maintenance">
+      <div className="px-4 py-5 sm:px-6">
+        <MaintenancePanel />
+      </div>
+    </AdminPanel>
+  );
+}

--- a/jamesduxbury/src/app/admin/page.tsx
+++ b/jamesduxbury/src/app/admin/page.tsx
@@ -26,6 +26,11 @@ export default async function AdminPage() {
       title: 'Analytics',
       meta: `${visits.last7Days} views / 7d · ${visits.allTime} all-time`,
     },
+    {
+      href: '/admin/maintenance',
+      title: 'Maintenance',
+      meta: 'heal and purge stored blobs',
+    },
   ];
 
   return (

--- a/jamesduxbury/src/components/BlobImage.tsx
+++ b/jamesduxbury/src/components/BlobImage.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import Image, { type ImageProps } from 'next/image';
+import { useState } from 'react';
+
+// a deleted blob 404s; hide the image and its wrapper frame rather than break layout
+export function BlobImage({
+  wrapperClassName,
+  ...props
+}: ImageProps & { wrapperClassName?: string }) {
+  // track the failed src so a later valid src is not left hidden
+  const [failedSrc, setFailedSrc] = useState<ImageProps['src'] | null>(null);
+  if (failedSrc === props.src) return null;
+  const image = <Image {...props} onError={() => setFailedSrc(props.src)} />;
+  return wrapperClassName ? <div className={wrapperClassName}>{image}</div> : image;
+}

--- a/jamesduxbury/src/components/Entry.tsx
+++ b/jamesduxbury/src/components/Entry.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import Image from 'next/image';
 import Link from 'next/link';
+import { BlobImage } from '@/components/BlobImage';
 import type { SiteSettings } from '@/data/site';
 import { cvDownloadName, cvHref } from '@/lib/cv';
 import { SectionHeader } from './console/SectionHeader';
@@ -16,7 +16,7 @@ export const Entry: React.FC<{ settings: SiteSettings }> = ({ settings }) => {
 
         <div className="grid grid-cols-1 gap-8 sm:grid-cols-[auto_1fr] sm:items-start sm:gap-12">
           <div className="relative h-36 w-36 overflow-hidden border border-border sm:h-40 sm:w-40 lg:h-44 lg:w-44">
-            <Image
+            <BlobImage
               src={settings.profileImage}
               alt={settings.ownerName}
               fill

--- a/jamesduxbury/src/components/admin/MaintenancePanel.tsx
+++ b/jamesduxbury/src/components/admin/MaintenancePanel.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useActionState } from 'react';
+import { runMaintenance } from '@/admin/actions';
+
+const button =
+  'border border-accent/60 bg-accent/10 px-4 py-2 font-mono text-xs uppercase tracking-[0.18em] text-accent transition-colors hover:border-accent hover:bg-accent hover:text-text disabled:opacity-50';
+
+export function MaintenancePanel() {
+  const [report, action, pending] = useActionState(runMaintenance, null);
+
+  return (
+    <form action={action} className="space-y-4">
+      <p className="font-mono text-sm text-muted">
+        checks every stored image and document, clears references whose file has vanished, and
+        deletes blobs no row points at
+      </p>
+      <button type="submit" disabled={pending} className={button}>
+        {pending ? 'running…' : 'run maintenance'}
+      </button>
+
+      {report && (
+        <div className="space-y-1 border border-border bg-bg/40 px-4 py-3 font-mono text-xs text-text/85">
+          <p>{report.healed.length} reference(s) cleared</p>
+          <p>{report.purged} unreferenced blob(s) deleted</p>
+          {report.dangling.length > 0 && (
+            <div className="text-danger">
+              <p>{report.dangling.length} dangling reference(s) need a re-upload:</p>
+              {report.dangling.map((d) => (
+                <p key={`${d.table}.${d.column}.${d.url}`}>
+                  {`>`} {d.table}.{d.column}
+                </p>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </form>
+  );
+}

--- a/jamesduxbury/src/components/admin/SectionForm.tsx
+++ b/jamesduxbury/src/components/admin/SectionForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import Image from 'next/image';
 import { useActionState, useRef, useState } from 'react';
+import { BlobImage } from '@/components/BlobImage';
 import type { FormState } from '@/admin/actions';
 import type { FieldDef, FieldDefault, MetricDraft } from '@/admin/fields';
 import { parseProse } from '@/admin/runs';
@@ -33,6 +33,15 @@ function UploadInput({ column, accept }: { column: string; accept: string }) {
       accept={accept}
       className={`${fieldInput} mt-0 cursor-pointer file:mr-4 file:cursor-pointer file:border-0 file:bg-transparent file:font-mono file:text-xs file:uppercase file:tracking-[0.18em] file:text-accent`}
     />
+  );
+}
+
+function RemoveControl({ column }: { column: string }) {
+  return (
+    <label className="mb-3 flex items-center gap-2 font-mono text-xs uppercase tracking-[0.18em] text-muted">
+      <input type="checkbox" name={`${column}.remove`} className="accent-accent" />
+      remove current file
+    </label>
   );
 }
 
@@ -261,7 +270,7 @@ function FieldInput({ field, defaultValue }: { field: FieldDef; defaultValue: Fi
       return (
         <div className="mt-2">
           {text && (
-            <Image
+            <BlobImage
               src={text}
               alt="current image"
               width={80}
@@ -270,6 +279,7 @@ function FieldInput({ field, defaultValue }: { field: FieldDef; defaultValue: Fi
               className="mb-3 border border-border object-cover"
             />
           )}
+          {text && <RemoveControl column={field.column} />}
           <UploadInput column={field.column} accept="image/png,image/jpeg,image/webp" />
         </div>
       );
@@ -286,6 +296,7 @@ function FieldInput({ field, defaultValue }: { field: FieldDef; defaultValue: Fi
               current file ↗
             </a>
           )}
+          {text && <RemoveControl column={field.column} />}
           <UploadInput column={field.column} accept="application/pdf" />
         </div>
       );

--- a/jamesduxbury/src/components/admin/SectionForm.tsx
+++ b/jamesduxbury/src/components/admin/SectionForm.tsx
@@ -38,9 +38,20 @@ function UploadInput({ column, accept }: { column: string; accept: string }) {
 
 function RemoveControl({ column }: { column: string }) {
   return (
-    <label className="mb-3 flex items-center gap-2 font-mono text-xs uppercase tracking-[0.18em] text-muted">
-      <input type="checkbox" name={`${column}.remove`} className="accent-accent" />
-      remove current file
+    <label className="mb-3 flex w-fit cursor-pointer items-center gap-3">
+      <span className="relative flex h-4 w-4 items-center justify-center">
+        <input
+          type="checkbox"
+          name={`${column}.remove`}
+          className="peer h-4 w-4 cursor-pointer appearance-none border border-border bg-bg transition-colors checked:border-accent checked:bg-accent focus:outline-none focus:ring-1 focus:ring-accent"
+        />
+        <span className="pointer-events-none absolute hidden font-mono text-[0.65rem] leading-none text-bg peer-checked:block">
+          ✓
+        </span>
+      </span>
+      <span className="font-mono text-xs uppercase tracking-[0.18em] text-muted">
+        remove current file
+      </span>
     </label>
   );
 }

--- a/jamesduxbury/src/components/education/CertificationsBlock.tsx
+++ b/jamesduxbury/src/components/education/CertificationsBlock.tsx
@@ -1,5 +1,5 @@
-import Image from 'next/image';
 import Link from 'next/link';
+import { BlobImage } from '@/components/BlobImage';
 import type { Certification } from '@/data/certifications';
 import { getCertifications } from '@/db/queries';
 
@@ -7,7 +7,7 @@ const Card: React.FC<Certification> = ({ name, year, imgPath, certificationLink 
   const inner = (
     <div className="flex items-center gap-3 border border-border bg-bg/40 p-3 transition-colors hover:border-accent">
       {imgPath ? (
-        <Image
+        <BlobImage
           src={imgPath}
           alt={name}
           width={48}

--- a/jamesduxbury/src/components/work/CaseStudyDetail.tsx
+++ b/jamesduxbury/src/components/work/CaseStudyDetail.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/image';
+import { BlobImage } from '@/components/BlobImage';
 import type { CaseStudy } from '@/data/case-studies';
 import { formatYearRange, type Project } from '@/data/projects';
 import { StatusChip } from '@/components/console/StatusChip';
@@ -50,15 +50,14 @@ export function CaseStudyDetail({ project, study }: CaseStudyDetailProps) {
       {study ? (
         <div className="mt-6 border border-border bg-surface/40 backdrop-blur-sm">
           {study.imagePath && (
-            <div className="border-b border-border">
-              <Image
-                src={study.imagePath}
-                alt={`${project.title} illustration`}
-                width={1200}
-                height={675}
-                className="h-auto w-full object-cover"
-              />
-            </div>
+            <BlobImage
+              wrapperClassName="border-b border-border"
+              src={study.imagePath}
+              alt={`${project.title} illustration`}
+              width={1200}
+              height={675}
+              className="h-auto w-full object-cover"
+            />
           )}
           <ProseSection label="Problem" paragraphs={study.problem} />
           <ProseSection label="Approach" paragraphs={study.approach} />

--- a/jamesduxbury/tests/admin-actions.test.ts
+++ b/jamesduxbury/tests/admin-actions.test.ts
@@ -295,6 +295,24 @@ describe('site settings singleton', () => {
     expect(state.fieldErrors.cv).toBe('Document must be a pdf');
   });
 
+  it('clears the cv and deletes its blob when remove is checked', async () => {
+    const url = 'https://abc.public.blob.vercel-storage.com/cv.pdf';
+    await sql`UPDATE site_settings SET cv = ${url} WHERE id = 1`;
+    const fd = siteForm();
+    fd.append('cv.remove', 'on');
+    await expect(saveItem('site', 1, EMPTY, fd)).rejects.toThrow('REDIRECT:/admin/site');
+    const [row] = await sql`SELECT cv FROM site_settings WHERE id = 1`;
+    expect(row.cv).toBeNull();
+    expect(deleteImageMock).toHaveBeenCalledWith(url);
+  });
+
+  it('rejects clearing the non-nullable profile image', async () => {
+    const fd = siteForm();
+    fd.append('profile_image.remove', 'on');
+    const state = await saveItem('site', 1, EMPTY, fd);
+    expect(state.fieldErrors.profile_image).toBeTruthy();
+  });
+
   it('rejects a second settings row', async () => {
     const fd = siteForm();
     fd.append('profile_image', new File([new Uint8Array(8)], 'extra.png', { type: 'image/png' }));

--- a/jamesduxbury/tests/admin-images.test.ts
+++ b/jamesduxbury/tests/admin-images.test.ts
@@ -59,7 +59,7 @@ describe('uploadImage', () => {
     putMock.mockResolvedValue({ url: BLOB_URL });
     const file = makeFile('profile.png', 'image/png');
     await expect(uploadImage(file)).resolves.toBe(BLOB_URL);
-    expect(putMock).toHaveBeenCalledWith('profile.png', file, {
+    expect(putMock).toHaveBeenCalledWith('dev/profile.png', file, {
       access: 'public',
       addRandomSuffix: true,
     });

--- a/jamesduxbury/tests/admin-kit.test.ts
+++ b/jamesduxbury/tests/admin-kit.test.ts
@@ -260,7 +260,12 @@ describe('section registry', () => {
     '%s: a filled form parses and validates',
     (slug) => {
       const section = getSection(slug);
-      const parsed = section.schema.safeParse(parseFields(section.fields, form(samples[slug])));
+      const values = parseFields(section.fields, form(samples[slug]));
+      // the action fills upload columns from the file or prior row; mimic that here
+      for (const f of section.fields) {
+        if (f.type === 'image' || f.type === 'document') values[f.column] = 'https://example/x';
+      }
+      const parsed = section.schema.safeParse(values);
       expect(parsed.success).toBe(true);
     },
   );

--- a/jamesduxbury/tests/blob-image.dom.test.tsx
+++ b/jamesduxbury/tests/blob-image.dom.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { BlobImage } from '../src/components/BlobImage';
+
+describe('BlobImage', () => {
+  it('renders the image until it fails, then hides it', () => {
+    const { container } = render(
+      <BlobImage src="https://x.public.blob.vercel-storage.com/dev/a.png" alt="a" width={10} height={10} />,
+    );
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    fireEvent.error(img!);
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('removes its wrapper frame on error', () => {
+    const { container } = render(
+      <BlobImage
+        wrapperClassName="frame"
+        src="https://x.public.blob.vercel-storage.com/dev/b.png"
+        alt="b"
+        width={10}
+        height={10}
+      />,
+    );
+    expect(container.querySelector('.frame')).not.toBeNull();
+    fireEvent.error(container.querySelector('img')!);
+    expect(container.querySelector('.frame')).toBeNull();
+  });
+});

--- a/jamesduxbury/tests/maintenance.test.ts
+++ b/jamesduxbury/tests/maintenance.test.ts
@@ -1,0 +1,70 @@
+import { neon } from '@neondatabase/serverless';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const DEAD = 'https://x.public.blob.vercel-storage.com/dev/dead.png';
+const ALIVE = 'https://x.public.blob.vercel-storage.com/dev/alive.png';
+const ORPHAN = 'https://x.public.blob.vercel-storage.com/dev/orphan.png';
+
+const deleteImageMock = vi.fn<(url: unknown) => Promise<void>>();
+const listEnvBlobsMock = vi.fn<() => Promise<string[]>>();
+
+vi.mock('../src/admin/images', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/admin/images')>();
+  return {
+    ...actual,
+    blobIsAlive: (url: string) => Promise.resolve(url !== DEAD),
+    listEnvBlobs: () => listEnvBlobsMock(),
+    deleteImage: (url: unknown) => deleteImageMock(url),
+  };
+});
+
+import { runBlobMaintenance } from '../src/admin/maintenance';
+
+const sql = neon(process.env.DATABASE_URL!);
+const certName = 'maintenance-test-cert';
+let originalProfile: string;
+
+beforeEach(async () => {
+  deleteImageMock.mockReset();
+  listEnvBlobsMock.mockReset().mockResolvedValue([]);
+  const [row] = await sql`SELECT profile_image FROM site_settings WHERE id = 1`;
+  originalProfile = row.profile_image;
+});
+
+afterEach(async () => {
+  await sql`DELETE FROM certifications WHERE name = ${certName}`;
+  await sql`UPDATE site_settings SET profile_image = ${originalProfile} WHERE id = 1`;
+});
+
+describe('runBlobMaintenance', () => {
+  it('nulls a nullable reference whose blob has vanished', async () => {
+    await sql`INSERT INTO certifications (name, year, img_path, sort_order)
+      VALUES (${certName}, '2024', ${DEAD}, 999)`;
+    const report = await runBlobMaintenance();
+    const [row] = await sql`SELECT img_path FROM certifications WHERE name = ${certName}`;
+    expect(row.img_path).toBeNull();
+    expect(report.healed).toContainEqual({ table: 'certifications', column: 'img_path' });
+  });
+
+  it('reports a dangling non-nullable reference without nulling it', async () => {
+    await sql`UPDATE site_settings SET profile_image = ${DEAD} WHERE id = 1`;
+    const report = await runBlobMaintenance();
+    const [row] = await sql`SELECT profile_image FROM site_settings WHERE id = 1`;
+    expect(row.profile_image).toBe(DEAD);
+    expect(report.dangling).toContainEqual({
+      table: 'site_settings',
+      column: 'profile_image',
+      url: DEAD,
+    });
+  });
+
+  it('deletes blobs no row references and keeps referenced ones', async () => {
+    await sql`INSERT INTO certifications (name, year, img_path, sort_order)
+      VALUES (${certName}, '2024', ${ALIVE}, 999)`;
+    listEnvBlobsMock.mockResolvedValue([ALIVE, ORPHAN]);
+    const report = await runBlobMaintenance();
+    expect(deleteImageMock).toHaveBeenCalledWith(ORPHAN);
+    expect(deleteImageMock).not.toHaveBeenCalledWith(ALIVE);
+    expect(report.purged).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #35. Stacked on #45.

- Remove checkbox on every image and document field clears the value and deletes the prior blob; a new file still wins over a remove. profile_image is non-nullable, so clearing it returns a field error rather than hitting the DB constraint.
- BlobImage hides an image (and its frame) when the blob 404s, so a file deleted out of band never renders a broken placeholder. Applied to the profile picture, certification badges, case-study image and the admin preview.
- /admin/maintenance reconciles the store: it clears references whose blob returns a definitive 404 and deletes blobs no row points at. Uploads are now prefixed by environment (dev/ vs prod/) in the shared store, so a purge is scoped to its own environment and never touches the other. Dangling non-nullable references (the profile image) are reported, not nulled.

Safety: a transient HEAD failure is treated as alive, never as gone, so maintenance only ever acts on a confirmed 404.

Verified: 253 tests green, build clean.

Merge order: #45 first, then this (it retargets to main automatically).