### PR TITLE
Add homepage top-level heading

### DIFF
--- a/jamesduxbury/src/components/Entry.tsx
+++ b/jamesduxbury/src/components/Entry.tsx
@@ -34,7 +34,9 @@ export const Entry: React.FC<{ settings: SiteSettings }> = ({ settings }) => {
           {/* spec rows */}
           <div className="divide-y divide-border border-y border-border">
             <SpecRow label="Name" trailing={<StatusChip kind="live" label="ACTIVE" />}>
-              <span className="font-mono text-base text-text sm:text-lg">{settings.ownerName}</span>
+              <h1 className="inline font-mono text-base font-normal text-text sm:text-lg">
+                {settings.ownerName}
+              </h1>
               <span className="ml-3 font-mono text-xs uppercase tracking-[0.2em] text-accent">
                 {settings.entryCredential}
               </span>

--- a/jamesduxbury/src/components/console/SpecRow.tsx
+++ b/jamesduxbury/src/components/console/SpecRow.tsx
@@ -11,7 +11,7 @@ export const SpecRow: React.FC<SpecRowProps> = ({ label, children, trailing }) =
     <span className="font-mono text-[0.65rem] uppercase tracking-[0.2em] text-muted sm:text-xs">
       {label}
     </span>
-    <span className="text-sm text-text sm:text-base">{children}</span>
+    <div className="text-sm text-text sm:text-base">{children}</div>
     {trailing && <span className="sm:justify-self-end">{trailing}</span>}
   </div>
 );

--- a/jamesduxbury/tests/ui.dom.test.tsx
+++ b/jamesduxbury/tests/ui.dom.test.tsx
@@ -64,6 +64,12 @@ describe('Entry', () => {
     expect(screen.getByText(siteSettings.ownerName)).toBeInTheDocument();
     expect(screen.getByText(siteSettings.entryRole)).toBeInTheDocument();
   });
+
+  it('uses the owner name as the homepage top-level heading', () => {
+    render(<Entry settings={siteSettings} />);
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(siteSettings.ownerName);
+  });
 });
 
 describe('Footer', () => {


### PR DESCRIPTION
## Summary

Adds a single top-level heading to the homepage by rendering the owner name as an `h1` in the entry panel while keeping the existing visual styling.

The `SpecRow` content wrapper now uses a `div`, so the heading is valid HTML instead of being nested inside a `span`.

Closes #50.

## Validation

- `node_modules/.bin/vitest.cmd run tests/ui.dom.test.tsx -t Entry --coverage=false`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)

`npm run format:check` still reports existing formatting drift across many files outside this change, so I kept this PR scoped to the accessibility fix.